### PR TITLE
Fix(elasticsearch, discovery):

### DIFF
--- a/pkg/discovery/kubernetes/controller/selectpodhandler.go
+++ b/pkg/discovery/kubernetes/controller/selectpodhandler.go
@@ -167,12 +167,12 @@ func (c *Controller) handleLogConfigPerPod(lgc *logconfigv1beta1.LogConfig, pod 
 
 	// compare and check if we should update
 	// FIXME Array order may causes inequality
-	if cmp.Equal(pipeCopy, cfgsInIndex) {
+	if cmp.Equal(pipeRaw, cfgsInIndex) {
 		return nil
 	}
 
 	// update index
-	if err := c.typePodIndex.ValidateAndSetConfigs(pod.Namespace, pod.Name, lgc.Name, pipeCopy); err != nil {
+	if err := c.typePodIndex.ValidateAndSetConfigs(pod.Namespace, pod.Name, lgc.Name, pipeRaw); err != nil {
 		return err
 	}
 

--- a/pkg/sink/elasticsearch/elasticsearch.go
+++ b/pkg/sink/elasticsearch/elasticsearch.go
@@ -74,7 +74,7 @@ func (s *Sink) Start() {
 	indexMatchers := codec.InitMatcher(s.config.Index)
 	cli, err := NewClient(s.config, s.codec, indexMatchers)
 	if err != nil {
-		log.Panic("start elasticsearch connection fail, err: %+v", err)
+		log.Error("start elasticsearch connection fail, err: %+v", err)
 		return
 	}
 	s.cli = cli


### PR DESCRIPTION
1. do not panic when init es client error.
2. ignore defaults when logConfig to pipelines yaml.