### PR TITLE
Feat: update logAlert interceptor, rename some fields, optimize regexp

### DIFF
--- a/pkg/interceptor/logalert/alerting_test.go
+++ b/pkg/interceptor/logalert/alerting_test.go
@@ -19,6 +19,7 @@ package logalert
 import (
 	"loggie.io/loggie/pkg/core/api"
 	"loggie.io/loggie/pkg/core/event"
+	"regexp"
 	"testing"
 )
 
@@ -86,6 +87,13 @@ func TestInterceptor_match(t *testing.T) {
 			i := &Interceptor{
 				config: tt.fields.config,
 			}
+
+			var regex []*regexp.Regexp
+			for _, reg := range tt.fields.config.Matcher.Regexp {
+				regex = append(regex, regexp.MustCompile(reg))
+			}
+			i.regex = regex
+
 			gotMatched, reason, message := i.match(tt.args.event)
 			t.Logf("match() gotMatched = %v, want %v, reason: %s, message: %s", gotMatched, tt.wantMatched, reason, message)
 			if gotMatched != tt.wantMatched {

--- a/pkg/interceptor/logalert/config.go
+++ b/pkg/interceptor/logalert/config.go
@@ -28,11 +28,11 @@ type Config struct {
 type Matcher struct {
 	Regexp       []string `yaml:"regexp,omitempty"`
 	Contains     []string `yaml:"contains,omitempty"`
-	TargetHeader string   `yaml:"targetHeader,omitempty"`
+	TargetHeader string   `yaml:"target,omitempty"`
 }
 
 type Labels struct {
-	FromHeader []string `yaml:"fromHeader,omitempty"`
+	FromHeader []string `yaml:"from,omitempty"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
1. rename logAlert interceptor config fields
2. optimize regex
3. change logAlert interceptor to source type