### PR TITLE
Feat(source): Support specifying more time intervals(like 1d, 1w, 1y) for the "ignoreOlder" config of file source

### DIFF
--- a/cmd/loggie/main.go
+++ b/cmd/loggie/main.go
@@ -19,6 +19,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
 	"github.com/loggie-io/loggie/pkg/control"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/core/global"
@@ -32,11 +38,6 @@ import (
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"go.uber.org/automaxprocs/maxprocs"
 	"gopkg.in/yaml.v2"
-	"net/http"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 var (

--- a/pkg/control/config.go
+++ b/pkg/control/config.go
@@ -17,15 +17,16 @@ limitations under the License.
 package control
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"os"
-	"path/filepath"
 )
 
 var (

--- a/pkg/control/config_test.go
+++ b/pkg/control/config_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package control
 
 import (
+	"testing"
+
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/core/source"
 	_ "github.com/loggie-io/loggie/pkg/queue/memory"
 	_ "github.com/loggie-io/loggie/pkg/sink/dev"
 	_ "github.com/loggie-io/loggie/pkg/source/file"
 	"github.com/pkg/errors"
-	"testing"
 )
 
 var (

--- a/pkg/control/controller.go
+++ b/pkg/control/controller.go
@@ -17,14 +17,15 @@ limitations under the License.
 package control
 
 import (
+	"net/http"
+	_ "net/http/pprof"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"gopkg.in/yaml.v2"
-	"net/http"
-	_ "net/http/pprof"
-	"time"
 )
 
 const handleCurrentPipelines = "/api/v1/controller/pipelines"

--- a/pkg/core/batch/batch.go
+++ b/pkg/core/batch/batch.go
@@ -17,9 +17,10 @@ limitations under the License.
 package batch
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/api"
 	"sync"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
 )
 
 type DefaultBatch struct {

--- a/pkg/core/cfg/cfg.go
+++ b/pkg/core/cfg/cfg.go
@@ -18,12 +18,13 @@ package cfg
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/creasty/defaults"
 	"github.com/go-playground/validator/v10"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"os"
 )
 
 type CommonCfg map[string]interface{}

--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -18,9 +18,10 @@ package event
 
 import (
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/api"
 	"strings"
 	"sync"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
 )
 
 const (

--- a/pkg/core/log/global.go
+++ b/pkg/core/log/global.go
@@ -19,11 +19,12 @@ package log
 import (
 	"flag"
 	"fmt"
-	"github.com/rs/zerolog"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"io"
 	"os"
 	"path"
+
+	"github.com/rs/zerolog"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/loggie-io/loggie/pkg/core/log/spi"
 )

--- a/pkg/core/reloader/http.go
+++ b/pkg/core/reloader/http.go
@@ -17,11 +17,12 @@ limitations under the License.
 package reloader
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 const handleReadPipelineConfigPath = "/api/v1/reload/config"

--- a/pkg/core/reloader/reload.go
+++ b/pkg/core/reloader/reload.go
@@ -17,6 +17,9 @@ limitations under the License.
 package reloader
 
 import (
+	"os"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/loggie-io/loggie/pkg/control"
@@ -27,8 +30,6 @@ import (
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"gopkg.in/yaml.v2"
-	"os"
-	"time"
 )
 
 type Reloader struct {

--- a/pkg/core/sink/interceptor.go
+++ b/pkg/core/sink/interceptor.go
@@ -18,9 +18,10 @@ package sink
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/interceptor"
-	"sort"
 )
 
 type Interceptor interface {

--- a/pkg/core/source/interceptor.go
+++ b/pkg/core/source/interceptor.go
@@ -17,9 +17,10 @@ limitations under the License.
 package source
 
 import (
+	"sort"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/interceptor"
-	"sort"
 )
 
 type Interceptor interface {

--- a/pkg/discovery/kubernetes/controller/controller.go
+++ b/pkg/discovery/kubernetes/controller/controller.go
@@ -18,6 +18,9 @@ package controller
 
 import (
 	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/log"
 	logconfigClientset "github.com/loggie-io/loggie/pkg/discovery/kubernetes/client/clientset/versioned"
 	logconfigSchema "github.com/loggie-io/loggie/pkg/discovery/kubernetes/client/clientset/versioned/scheme"
@@ -30,8 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"reflect"
-	"time"
 
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -406,7 +407,7 @@ func (c *Controller) processNextWorkItem() bool {
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queued again until another change happens.
 		c.workqueue.Forget(obj)
-		//log.Debug("Successfully synced '%s'", element)
+		// log.Debug("Successfully synced '%s'", element)
 		return nil
 	}(obj)
 

--- a/pkg/discovery/kubernetes/controller/reconcile.go
+++ b/pkg/discovery/kubernetes/controller/reconcile.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/control"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	logconfigv1beta1 "github.com/loggie-io/loggie/pkg/discovery/kubernetes/apis/loggie/v1beta1"

--- a/pkg/discovery/kubernetes/external/podindexer.go
+++ b/pkg/discovery/kubernetes/external/podindexer.go
@@ -17,13 +17,14 @@ limitations under the License.
 package external
 
 import (
+	"sync"
+
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/discovery/kubernetes/helper"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"sync"
 )
 
 const (

--- a/pkg/discovery/kubernetes/helper/config.go
+++ b/pkg/discovery/kubernetes/helper/config.go
@@ -18,6 +18,7 @@ package helper
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/control"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	logconfigv1beta1 "github.com/loggie-io/loggie/pkg/discovery/kubernetes/apis/loggie/v1beta1"

--- a/pkg/eventbus/api.go
+++ b/pkg/eventbus/api.go
@@ -17,8 +17,9 @@ limitations under the License.
 package eventbus
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/api"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
 )
 
 type Event struct {

--- a/pkg/eventbus/base.go
+++ b/pkg/eventbus/base.go
@@ -20,10 +20,11 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/api"
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"strings"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 const (

--- a/pkg/eventbus/export/alertmanager/alertmanager.go
+++ b/pkg/eventbus/export/alertmanager/alertmanager.go
@@ -19,10 +19,11 @@ package alertmanager
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 type AlertManager struct {

--- a/pkg/eventbus/export/prometheus/prometheus.go
+++ b/pkg/eventbus/export/prometheus/prometheus.go
@@ -17,10 +17,11 @@ limitations under the License.
 package prometheus
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (

--- a/pkg/eventbus/listener/filesource/listener.go
+++ b/pkg/eventbus/listener/filesource/listener.go
@@ -18,15 +18,16 @@ package filesource
 
 import (
 	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/eventbus/export/logger"
 	promeExporter "github.com/loggie-io/loggie/pkg/eventbus/export/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	"os"
-	"strings"
-	"time"
 )
 
 const name = "filesource"

--- a/pkg/eventbus/listener/filewatcher/listener.go
+++ b/pkg/eventbus/listener/filewatcher/listener.go
@@ -18,6 +18,9 @@ package filewatcher
 
 import (
 	"encoding/json"
+	"strings"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
@@ -25,8 +28,6 @@ import (
 	promeExporter "github.com/loggie-io/loggie/pkg/eventbus/export/prometheus"
 	"github.com/loggie-io/loggie/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"strings"
-	"time"
 )
 
 const name = "filewatcher"

--- a/pkg/eventbus/listener/logalerting/alerting.go
+++ b/pkg/eventbus/listener/logalerting/alerting.go
@@ -18,11 +18,12 @@ package logalerting
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/eventbus/export/alertmanager"
-	"time"
 )
 
 const name = "logAlert"

--- a/pkg/eventbus/listener/pipeline/listener.go
+++ b/pkg/eventbus/listener/pipeline/listener.go
@@ -17,11 +17,12 @@ limitations under the License.
 package pipeline
 
 import (
+	"strings"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
-	"strings"
-	"time"
 )
 
 const name = "pipeline"

--- a/pkg/eventbus/listener/reload/listener.go
+++ b/pkg/eventbus/listener/reload/listener.go
@@ -18,13 +18,14 @@ package reload
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/eventbus/export/logger"
 	promeExporter "github.com/loggie-io/loggie/pkg/eventbus/export/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	"time"
 )
 
 const name = "reload"

--- a/pkg/eventbus/listener/sink/listener.go
+++ b/pkg/eventbus/listener/sink/listener.go
@@ -18,14 +18,15 @@ package sink
 
 import (
 	"encoding/json"
+	"strings"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/eventbus/export/logger"
 	promeExporter "github.com/loggie-io/loggie/pkg/eventbus/export/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
-	"strings"
-	"time"
 )
 
 const name = "sink"

--- a/pkg/interceptor/addk8smeta/interceptor.go
+++ b/pkg/interceptor/addk8smeta/interceptor.go
@@ -18,6 +18,7 @@ package addk8smeta
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/global"
 	"github.com/loggie-io/loggie/pkg/core/log"

--- a/pkg/interceptor/cost/interceptor.go
+++ b/pkg/interceptor/cost/interceptor.go
@@ -18,12 +18,13 @@ package cost
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/sink"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	"math/rand"
-	"time"
 )
 
 const Type = "cost"

--- a/pkg/interceptor/json_decode/interceptor.go
+++ b/pkg/interceptor/json_decode/interceptor.go
@@ -18,6 +18,8 @@ package json_decode
 
 import (
 	"fmt"
+	"strings"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
@@ -25,7 +27,6 @@ import (
 	"github.com/loggie-io/loggie/pkg/core/source"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 const Type = "jsonDecode"

--- a/pkg/interceptor/json_decode/interceptor_test.go
+++ b/pkg/interceptor/json_decode/interceptor_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package json_decode
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
-	"strings"
-	"testing"
 )
 
 func init() {

--- a/pkg/interceptor/limit/interceptor.go
+++ b/pkg/interceptor/limit/interceptor.go
@@ -18,6 +18,7 @@ package limit
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/source"

--- a/pkg/interceptor/limit/limiter.go
+++ b/pkg/interceptor/limit/limiter.go
@@ -17,8 +17,9 @@ limitations under the License.
 package limit
 
 import (
-	"github.com/andres-erbsen/clock"
 	"time"
+
+	"github.com/andres-erbsen/clock"
 )
 
 // Limiter is used to rate-limit some process, possibly across goroutines.

--- a/pkg/interceptor/logalert/alerting.go
+++ b/pkg/interceptor/logalert/alerting.go
@@ -18,14 +18,15 @@ package logalert
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/global"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/source"
 	"github.com/loggie-io/loggie/pkg/eventbus"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	"regexp"
-	"strings"
 )
 
 const Type = "logAlert"

--- a/pkg/interceptor/logalert/alerting_test.go
+++ b/pkg/interceptor/logalert/alerting_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package logalert
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/api"
-	"github.com/loggie-io/loggie/pkg/core/event"
 	"regexp"
 	"testing"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/event"
 )
 
 func TestInterceptor_match(t *testing.T) {

--- a/pkg/interceptor/maxbytes/interceptor.go
+++ b/pkg/interceptor/maxbytes/interceptor.go
@@ -18,6 +18,7 @@ package maxbytes
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/source"
 	"github.com/loggie-io/loggie/pkg/pipeline"

--- a/pkg/interceptor/metric/interceptor.go
+++ b/pkg/interceptor/metric/interceptor.go
@@ -18,6 +18,7 @@ package metric
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/sink"
 	"github.com/loggie-io/loggie/pkg/eventbus"

--- a/pkg/interceptor/normalize/addmeta.go
+++ b/pkg/interceptor/normalize/addmeta.go
@@ -17,13 +17,14 @@ limitations under the License.
 package normalize
 
 import (
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	eventer "github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/pkg/errors"
-	"reflect"
-	"strings"
-	"time"
 )
 
 const ProcessorAddMeta = "addMeta"

--- a/pkg/interceptor/normalize/interceptor.go
+++ b/pkg/interceptor/normalize/interceptor.go
@@ -18,6 +18,7 @@ package normalize
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/source"

--- a/pkg/interceptor/normalize/regex.go
+++ b/pkg/interceptor/normalize/regex.go
@@ -17,12 +17,13 @@ limitations under the License.
 package normalize
 
 import (
+	"regexp"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/util"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
-	"regexp"
 )
 
 const ProcessorRegex = "regex"

--- a/pkg/interceptor/normalize/split.go
+++ b/pkg/interceptor/normalize/split.go
@@ -17,12 +17,13 @@ limitations under the License.
 package normalize
 
 import (
+	"strings"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/util"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
-	"strings"
 )
 
 const ProcessorSplit = "split"

--- a/pkg/interceptor/normalize/timestamp.go
+++ b/pkg/interceptor/normalize/timestamp.go
@@ -17,11 +17,12 @@ limitations under the License.
 package normalize
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
-	"strconv"
-	"time"
 )
 
 const ProcessorTimestamp = "timestamp"

--- a/pkg/interceptor/retry/interceptor.go
+++ b/pkg/interceptor/retry/interceptor.go
@@ -18,15 +18,16 @@ package retry
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/interceptor"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/sink"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"github.com/mmaxiaolei/backoff"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const Type = "retry"
@@ -104,7 +105,7 @@ func (i *Interceptor) Init(context api.Context) error {
 
 func (i *Interceptor) initBackOff() {
 	bo := backoff.NewExponentialBackoff()
-	//bo.MaxElapsedTime = 0
+	// bo.MaxElapsedTime = 0
 	i.bo = bo
 }
 

--- a/pkg/pipeline/info.go
+++ b/pkg/pipeline/info.go
@@ -17,6 +17,9 @@ limitations under the License.
 package pipeline
 
 import (
+	"log"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/core/event"
@@ -25,8 +28,6 @@ import (
 	"github.com/loggie-io/loggie/pkg/core/sink"
 	"github.com/loggie-io/loggie/pkg/core/source"
 	"gopkg.in/yaml.v2"
-	"log"
-	"time"
 )
 
 type Config struct {

--- a/pkg/pipeline/manage.go
+++ b/pkg/pipeline/manage.go
@@ -18,10 +18,11 @@ package pipeline
 
 import (
 	"fmt"
+	"sync"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/spi"
-	"sync"
 )
 
 var codeFactory = map[string]Factory{}
@@ -165,7 +166,7 @@ func (r *RegisterCenter) RegisterListener(listener spi.ComponentListener) {
 	name := listener.Name()
 	_, ok := r.nameListeners[name]
 	if ok {
-		//panic(fmt.Sprintf("component listener[%s] is exist", name))
+		// panic(fmt.Sprintf("component listener[%s] is exist", name))
 		log.Warn("component listener[%s] is exist", name)
 		return
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -17,6 +17,11 @@ limitations under the License.
 package pipeline
 
 import (
+	"os"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/core/context"
@@ -30,10 +35,6 @@ import (
 	"github.com/loggie-io/loggie/pkg/sink/codec"
 	"github.com/loggie-io/loggie/pkg/util"
 	"github.com/pkg/errors"
-	"os"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -265,7 +266,7 @@ func (p *Pipeline) startQueue(queueConfig queue.Config) error {
 func (p *Pipeline) startComponent(ctx api.Context) error {
 	component, _ := GetWithType(ctx.Category(), ctx.Type(), p.info)
 	if err := p.startWithComponent(component, ctx); err != nil {
-		//log.Error("start component failed: %v", err)
+		// log.Error("start component failed: %v", err)
 		return err
 	}
 	return nil
@@ -488,7 +489,7 @@ func buildSinkInvokerChain(invoker sink.Invoker, interceptors []sink.Interceptor
 	sink.SortableInterceptor(interceptors).Sort()
 	// build chain
 	for _, ic := range interceptors {
-		//filter retry ignore
+		// filter retry ignore
 		if retry {
 			if extension, ok := ic.(interceptor.Extension); ok && extension.IgnoreRetry() {
 				continue
@@ -567,7 +568,7 @@ func (p *Pipeline) startSourceProduct(sourceConfigs []source.Config) {
 		}
 		go si.Source.ProductLoop(productFunc)
 	}
-	//go p.sourceInvokeLoop(si)
+	// go p.sourceInvokeLoop(si)
 }
 
 func (p *Pipeline) fillEventMetaAndHeader(e api.Event, config source.Config) {

--- a/pkg/queue/memory/memory_test.go
+++ b/pkg/queue/memory/memory_test.go
@@ -18,12 +18,13 @@ package memory
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/context"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	"testing"
-	"time"
 )
 
 func TestQueue_Consume(t *testing.T) {

--- a/pkg/sink/codec/json/json.go
+++ b/pkg/sink/codec/json/json.go
@@ -17,11 +17,12 @@ limitations under the License.
 package json
 
 import (
+	"time"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/loggie-io/loggie/pkg/core/api"
 	eventer "github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/sink/codec"
-	"time"
 )
 
 var (

--- a/pkg/sink/codec/json/json_test.go
+++ b/pkg/sink/codec/json/json_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package json
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/api"
-	"github.com/loggie-io/loggie/pkg/core/event"
 	"reflect"
 	"testing"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/event"
 )
 
 func TestJson_Encode(t *testing.T) {

--- a/pkg/sink/dev/sink.go
+++ b/pkg/sink/dev/sink.go
@@ -18,11 +18,12 @@ package dev
 
 import (
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/result"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	codec "github.com/loggie-io/loggie/pkg/sink/codec"
+	"github.com/loggie-io/loggie/pkg/sink/codec"
 )
 
 const Type = "dev"

--- a/pkg/sink/elasticsearch/client.go
+++ b/pkg/sink/elasticsearch/client.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/sink/codec"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
 	es "github.com/olivere/elastic/v7"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 type ClientSet struct {

--- a/pkg/sink/elasticsearch/elasticsearch.go
+++ b/pkg/sink/elasticsearch/elasticsearch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/util/pattern"
 
 	"github.com/loggie-io/loggie/pkg/core/api"

--- a/pkg/sink/file/sink.go
+++ b/pkg/sink/file/sink.go
@@ -18,9 +18,10 @@ package file
 
 import (
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/util/pattern"
 	"strings"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/util/pattern"
 
 	"github.com/loggie-io/loggie/pkg/util/consistent"
 

--- a/pkg/sink/grpc/resolve.go
+++ b/pkg/sink/grpc/resolve.go
@@ -18,6 +18,7 @@ package grpc
 
 import (
 	"fmt"
+
 	"google.golang.org/grpc/resolver"
 )
 

--- a/pkg/sink/grpc/sink.go
+++ b/pkg/sink/grpc/sink.go
@@ -19,6 +19,10 @@ package grpc
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
+	"time"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
@@ -28,9 +32,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/resolver"
-	"io"
-	"strings"
-	"time"
 )
 
 const Type = "grpc"

--- a/pkg/sink/kafka/sink.go
+++ b/pkg/sink/kafka/sink.go
@@ -19,6 +19,7 @@ package kafka
 import (
 	"context"
 	"fmt"
+
 	"github.com/loggie-io/loggie/pkg/util/pattern"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
 	"github.com/pkg/errors"

--- a/pkg/sink/loki/logproto/timestamp.go
+++ b/pkg/sink/loki/logproto/timestamp.go
@@ -2,8 +2,8 @@ package logproto
 
 import (
 	"errors"
-	strconv "strconv"
-	time "time"
+	"strconv"
+	"time"
 
 	"github.com/gogo/protobuf/types"
 )

--- a/pkg/sink/loki/loki.go
+++ b/pkg/sink/loki/loki.go
@@ -5,6 +5,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"time"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/loggie-io/loggie/pkg/core/api"
@@ -19,9 +23,6 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"golang.org/x/net/context"
-	"io"
-	"net/http"
-	"time"
 )
 
 const Type = "loki"

--- a/pkg/source/file/ack.go
+++ b/pkg/source/file/ack.go
@@ -18,11 +18,12 @@ package file
 
 import (
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	"sync"
-	"time"
 )
 
 const (

--- a/pkg/source/file/config.go
+++ b/pkg/source/file/config.go
@@ -19,6 +19,8 @@ package file
 import (
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/util"
+	"github.com/prometheus/common/model"
+
 	"os"
 	"regexp"
 	"time"
@@ -35,20 +37,20 @@ type Config struct {
 }
 
 type CollectConfig struct {
-	IsolationLevel           string        `yaml:"isolationLevel,omitempty" default:"share"`
-	Paths                    []string      `yaml:"paths,omitempty" validate:"required"` // glob pattern
-	ExcludeFiles             []string      `yaml:"excludeFiles,omitempty"`              // regular pattern
-	IgnoreOlder              time.Duration `yaml:"ignoreOlder,omitempty"`
-	IgnoreSymlink            bool          `yaml:"ignoreSymlink,omitempty" default:"false"`
-	RereadTruncated          bool          `yaml:"rereadTruncated,omitempty" default:"true"`                           // Read from the beginning when the file is truncated
-	FirstNBytesForIdentifier int           `yaml:"firstNBytesForIdentifier,omitempty" default:"128" validate:"gte=10"` // If the file size is smaller than `firstNBytesForIdentifier`, it will not be collected
-	AddonMeta                bool          `yaml:"addonMeta,omitempty"`
+	IsolationLevel           string         `yaml:"isolationLevel,omitempty" default:"share"`
+	Paths                    []string       `yaml:"paths,omitempty" validate:"required"` // glob pattern
+	ExcludeFiles             []string       `yaml:"excludeFiles,omitempty"`              // regular pattern
+	IgnoreOlder              model.Duration `yaml:"ignoreOlder,omitempty"`
+	IgnoreSymlink            bool           `yaml:"ignoreSymlink,omitempty" default:"false"`
+	RereadTruncated          bool           `yaml:"rereadTruncated,omitempty" default:"true"`                           // Read from the beginning when the file is truncated
+	FirstNBytesForIdentifier int            `yaml:"firstNBytesForIdentifier,omitempty" default:"128" validate:"gte=10"` // If the file size is smaller than `firstNBytesForIdentifier`, it will not be collected
+	AddonMeta                bool           `yaml:"addonMeta,omitempty"`
 	excludeFilePatterns      []*regexp.Regexp
 }
 
 func (cc CollectConfig) IsIgnoreOlder(info os.FileInfo) bool {
 	ignoreOlder := cc.IgnoreOlder
-	return ignoreOlder > 0 && time.Since(info.ModTime()) > ignoreOlder
+	return ignoreOlder > 0 && time.Since(info.ModTime()) > time.Duration(ignoreOlder)
 }
 
 func (cc CollectConfig) IsFileInclude(file string) bool {

--- a/pkg/source/file/config.go
+++ b/pkg/source/file/config.go
@@ -17,13 +17,12 @@ limitations under the License.
 package file
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/log"
-	"github.com/loggie-io/loggie/pkg/util"
-	"github.com/prometheus/common/model"
-
 	"os"
 	"regexp"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/loggie-io/loggie/pkg/util"
 )
 
 type Config struct {
@@ -37,20 +36,20 @@ type Config struct {
 }
 
 type CollectConfig struct {
-	IsolationLevel           string         `yaml:"isolationLevel,omitempty" default:"share"`
-	Paths                    []string       `yaml:"paths,omitempty" validate:"required"` // glob pattern
-	ExcludeFiles             []string       `yaml:"excludeFiles,omitempty"`              // regular pattern
-	IgnoreOlder              model.Duration `yaml:"ignoreOlder,omitempty"`
-	IgnoreSymlink            bool           `yaml:"ignoreSymlink,omitempty" default:"false"`
-	RereadTruncated          bool           `yaml:"rereadTruncated,omitempty" default:"true"`                           // Read from the beginning when the file is truncated
-	FirstNBytesForIdentifier int            `yaml:"firstNBytesForIdentifier,omitempty" default:"128" validate:"gte=10"` // If the file size is smaller than `firstNBytesForIdentifier`, it will not be collected
-	AddonMeta                bool           `yaml:"addonMeta,omitempty"`
+	IsolationLevel           string        `yaml:"isolationLevel,omitempty" default:"share"`
+	Paths                    []string      `yaml:"paths,omitempty" validate:"required"` // glob pattern
+	ExcludeFiles             []string      `yaml:"excludeFiles,omitempty"`              // regular pattern
+	IgnoreOlder              util.Duration `yaml:"ignoreOlder,omitempty"`
+	IgnoreSymlink            bool          `yaml:"ignoreSymlink,omitempty" default:"false"`
+	RereadTruncated          bool          `yaml:"rereadTruncated,omitempty" default:"true"`                           // Read from the beginning when the file is truncated
+	FirstNBytesForIdentifier int           `yaml:"firstNBytesForIdentifier,omitempty" default:"128" validate:"gte=10"` // If the file size is smaller than `firstNBytesForIdentifier`, it will not be collected
+	AddonMeta                bool          `yaml:"addonMeta,omitempty"`
 	excludeFilePatterns      []*regexp.Regexp
 }
 
 func (cc CollectConfig) IsIgnoreOlder(info os.FileInfo) bool {
 	ignoreOlder := cc.IgnoreOlder
-	return ignoreOlder > 0 && time.Since(info.ModTime()) > time.Duration(ignoreOlder)
+	return ignoreOlder.Duration() > 0 && time.Since(info.ModTime()) > ignoreOlder.Duration()
 }
 
 func (cc CollectConfig) IsFileInclude(file string) bool {

--- a/pkg/source/file/http.go
+++ b/pkg/source/file/http.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hpcloud/tail"
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"io"
 	"net/http"
 	"os"
 	"strconv"
 	"sync"
+
+	"github.com/hpcloud/tail"
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 var once sync.Once

--- a/pkg/source/file/job.go
+++ b/pkg/source/file/job.go
@@ -19,7 +19,6 @@ package file
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/global"
 	"io"
 	"os"
 	"strconv"
@@ -27,6 +26,8 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/global"
 
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/util"

--- a/pkg/source/file/multilines.go
+++ b/pkg/source/file/multilines.go
@@ -18,15 +18,16 @@ package file
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/result"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"github.com/loggie-io/loggie/pkg/util"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -156,8 +157,8 @@ func (mh *MultiHolder) flush() {
 		LineNumber:   mh.state.LineNumber,
 		watchUid:     mh.state.watchUid,
 	}
-	//contentBuffer := make([]byte, mh.currentSize)
-	//copy(contentBuffer, mh.content)
+	// contentBuffer := make([]byte, mh.currentSize)
+	// copy(contentBuffer, mh.content)
 	contentBuffer := mh.content
 
 	e := mh.mTask.eventPool.Get()

--- a/pkg/source/file/persistence.go
+++ b/pkg/source/file/persistence.go
@@ -19,13 +19,14 @@ package file
 import (
 	"database/sql"
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/api"
-	"github.com/loggie-io/loggie/pkg/core/log"
-	_ "github.com/mattn/go-sqlite3"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 const (
@@ -244,11 +245,11 @@ func (d *dbHandler) delete(r registry) {
 
 // only one thread invoke,without lock
 func (d *dbHandler) write(stats []*State) {
-	//start := time.Now()
-	//defer func() {
+	// start := time.Now()
+	// defer func() {
 	//	cost := time.Since(start).Milliseconds()
 	//	log.Info("write cost: %dms", cost)
-	//}()
+	// }()
 
 	css := compressStats(stats)
 
@@ -386,11 +387,11 @@ func (d *dbHandler) txWrapper(sqlString string, f func(stmt *sql.Stmt)) {
 }
 
 func (d *dbHandler) findAll() []registry {
-	//start := time.Now()
-	//defer func() {
+	// start := time.Now()
+	// defer func() {
 	//	cost := time.Since(start).Milliseconds()
 	//	log.Info("find by source cost: %dms", cost)
-	//}()
+	// }()
 	return d.findBySql(queryAll)
 }
 

--- a/pkg/source/file/persistence_test.go
+++ b/pkg/source/file/persistence_test.go
@@ -19,11 +19,12 @@ package file
 import (
 	"database/sql"
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 func TestNewDB(t *testing.T) {

--- a/pkg/source/file/read.go
+++ b/pkg/source/file/read.go
@@ -18,13 +18,14 @@ package file
 
 import (
 	"bytes"
+	"io"
+	"sync"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"github.com/pkg/errors"
-	"io"
-	"sync"
-	"time"
 )
 
 const (
@@ -192,10 +193,10 @@ func (r *Reader) work(index int) {
 					backlogBuffer = append(backlogBuffer, readBuffer[processed:]...)
 
 					// TODO check whether it is too long to avoid bursting the memory
-					//if len(backlogBuffer)>max_bytes{
+					// if len(backlogBuffer)>max_bytes{
 					//	log.Error
 					//	break
-					//}
+					// }
 				}
 
 				wasSend = processed != 0

--- a/pkg/source/file/source.go
+++ b/pkg/source/file/source.go
@@ -18,11 +18,12 @@ package file
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	"time"
 )
 
 const Type = "file"

--- a/pkg/source/file/task.go
+++ b/pkg/source/file/task.go
@@ -17,15 +17,16 @@ limitations under the License.
 package file
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/api"
-	"github.com/loggie-io/loggie/pkg/core/event"
-	"github.com/loggie-io/loggie/pkg/core/log"
-	"github.com/loggie-io/loggie/pkg/pipeline"
 	"os"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/event"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/loggie-io/loggie/pkg/pipeline"
 )
 
 const (

--- a/pkg/source/file/watch.go
+++ b/pkg/source/file/watch.go
@@ -18,14 +18,15 @@ package file
 
 import (
 	"fmt"
-	"github.com/fsnotify/fsnotify"
-	"github.com/loggie-io/loggie/pkg/core/log"
-	"github.com/loggie-io/loggie/pkg/eventbus"
-	"github.com/loggie-io/loggie/pkg/util"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/loggie-io/loggie/pkg/eventbus"
+	"github.com/loggie-io/loggie/pkg/util"
 )
 
 const (
@@ -190,7 +191,7 @@ func (w *Watcher) decideJob(job *Job) {
 		w.zombieJobChan <- job
 		return
 	}
-	//w.activeChan <- job
+	// w.activeChan <- job
 	job.Read()
 }
 
@@ -208,7 +209,7 @@ func (w *Watcher) reportMetric(job *Job) {
 		Offset:     job.endOffset,
 		LineNumber: job.currentLineNumber,
 		Lines:      job.currentLines,
-		//FileSize:   fileSize,
+		// FileSize:   fileSize,
 		SourceFields: job.task.sourceFields,
 	}
 	eventbus.PublishOrDrop(eventbus.FileSourceMetricTopic, collectMetricData)
@@ -448,7 +449,7 @@ func (w *Watcher) legalFile(filename string, watchTask *WatchTask, withIgnoreOld
 
 	// Ignores all files which fall under ignore_older
 	if withIgnoreOlder && watchTask.config.IsIgnoreOlder(fileInfo) {
-		log.Debug("[pipeline(%s)-source(%s)]: ignore file(%s) because ignore_older(%d second) reached", pipelineName, sourceName, filename, watchTask.config.IgnoreOlder/time.Second)
+		log.Debug("[pipeline(%s)-source(%s)]: ignore file(%s) because ignore_older(%d second) reached", pipelineName, sourceName, filename, time.Duration(watchTask.config.IgnoreOlder)/time.Second)
 		return false, "", nil
 	}
 	return true, filename, fileInfo
@@ -618,7 +619,7 @@ func (w *Watcher) run() {
 		case job := <-w.zombieJobChan:
 			w.decideZombieJob(job)
 		case e := <-osEvents:
-			//log.Info("os event: %v", e)
+			// log.Info("os event: %v", e)
 			w.osNotify(e)
 		case <-scanFileTicker.C:
 			w.scan()

--- a/pkg/source/file/watch.go
+++ b/pkg/source/file/watch.go
@@ -449,7 +449,7 @@ func (w *Watcher) legalFile(filename string, watchTask *WatchTask, withIgnoreOld
 
 	// Ignores all files which fall under ignore_older
 	if withIgnoreOlder && watchTask.config.IsIgnoreOlder(fileInfo) {
-		log.Debug("[pipeline(%s)-source(%s)]: ignore file(%s) because ignore_older(%d second) reached", pipelineName, sourceName, filename, time.Duration(watchTask.config.IgnoreOlder)/time.Second)
+		log.Debug("[pipeline(%s)-source(%s)]: ignore file(%s) because ignore_older(%d second) reached", pipelineName, sourceName, filename, watchTask.config.IgnoreOlder.Duration()/time.Second)
 		return false, "", nil
 	}
 	return true, filename, fileInfo

--- a/pkg/source/file/watch_test.go
+++ b/pkg/source/file/watch_test.go
@@ -18,11 +18,12 @@ package file
 
 import (
 	"fmt"
-	"github.com/mattn/go-zglob"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mattn/go-zglob"
 )
 
 func TestWatcher_scanNewFiles(t *testing.T) {
@@ -41,7 +42,7 @@ func TestWatcher_scanNewFiles(t *testing.T) {
 func TestMach(t *testing.T) {
 	path := "/tmp/loggie/**/"
 	file := "/tmp/loggie/test/loggie.log"
-	//match, err := filepath.Match(path, file)
+	// match, err := filepath.Match(path, file)
 	if strings.HasSuffix(path, "**") {
 		path += "/*"
 	}

--- a/pkg/source/grpc/batch.go
+++ b/pkg/source/grpc/batch.go
@@ -17,13 +17,14 @@ limitations under the License.
 package grpc
 
 import (
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	pb "github.com/loggie-io/loggie/pkg/sink/grpc/pb"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 const (

--- a/pkg/source/grpc/source.go
+++ b/pkg/source/grpc/source.go
@@ -18,6 +18,9 @@ package grpc
 
 import (
 	"fmt"
+	"io"
+	"net"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
@@ -26,8 +29,6 @@ import (
 	pb "github.com/loggie-io/loggie/pkg/sink/grpc/pb"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"io"
-	"net"
 )
 
 const Type = "grpc"

--- a/pkg/source/kafka/config.go
+++ b/pkg/source/kafka/config.go
@@ -17,9 +17,10 @@ limitations under the License.
 package kafka
 
 import (
-	"github.com/pkg/errors"
 	"regexp"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/segmentio/kafka-go"
 )

--- a/pkg/source/kubernetes_event/eventer.go
+++ b/pkg/source/kubernetes_event/eventer.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/global"
@@ -32,7 +34,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"time"
 )
 
 const Type = "kubeEvent"

--- a/pkg/source/prometheus_exporter/prometheus.go
+++ b/pkg/source/prometheus_exporter/prometheus.go
@@ -4,6 +4,12 @@ import (
 	ctx "context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
@@ -12,11 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/prom2json"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 const Type = "prometheusExporter"

--- a/pkg/source/unix/unixsock.go
+++ b/pkg/source/unix/unixsock.go
@@ -4,16 +4,17 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/pipeline"
 	"github.com/pkg/errors"
 	"golang.org/x/net/netutil"
-	"net"
-	"os"
-	"strconv"
-	"time"
 )
 
 const Type = "unix"

--- a/pkg/util/execute.go
+++ b/pkg/util/execute.go
@@ -17,8 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 func AsyncRunWithTimeout(f func(), timeout time.Duration) {

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -19,14 +19,15 @@ package util
 import (
 	"bufio"
 	"bytes"
-	xglob "github.com/bmatcuk/doublestar/v4"
-	"github.com/loggie-io/loggie/pkg/core/log"
-	"github.com/pkg/errors"
 	"io"
 	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	xglob "github.com/bmatcuk/doublestar/v4"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/pkg/errors"
 )
 
 // LineCountTo calculates the number of lines to the offset

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"fmt"
-	xglob "github.com/bmatcuk/doublestar/v4"
 	"io"
 	"io/fs"
 	"os"
@@ -27,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	xglob "github.com/bmatcuk/doublestar/v4"
 )
 
 func TestLineCountTo(t *testing.T) {

--- a/pkg/util/match.go
+++ b/pkg/util/match.go
@@ -19,10 +19,11 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"regexp"
 	"regexp/syntax"
 	"strings"
+
+	"github.com/loggie-io/loggie/pkg/core/log"
 )
 
 type trans func(*syntax.Regexp) (bool, *syntax.Regexp)

--- a/pkg/util/runtime/object.go
+++ b/pkg/util/runtime/object.go
@@ -17,8 +17,9 @@ limitations under the License.
 package runtime
 
 import (
-	"github.com/pkg/errors"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 const sep = "."

--- a/pkg/util/runtime/select.go
+++ b/pkg/util/runtime/select.go
@@ -17,9 +17,10 @@ limitations under the License.
 package runtime
 
 import (
+	"strings"
+
 	"github.com/loggie-io/loggie/pkg/util"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 func GetQueryPaths(query string) []string {

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -48,6 +48,11 @@ type Duration struct {
 	duration model.Duration
 }
 
+// MarshalYAML implements the yaml.Marshaler interface.
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return d.String(), nil
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -19,6 +19,8 @@ package util
 import (
 	"strings"
 	"time"
+
+	"github.com/prometheus/common/model"
 )
 
 const (
@@ -40,4 +42,31 @@ func TimeFormatNow(pattern string) string {
 
 func UnixMilli(t time.Time) int64 {
 	return t.Unix()*1e3 + int64(t.Nanosecond())/1e6
+}
+
+type Duration struct {
+	duration model.Duration
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	dur, err := model.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	d.duration = dur
+	return nil
+}
+
+func (d *Duration) String() string {
+	return d.duration.String()
+}
+
+// Duration return time.duration struct
+func (d *Duration) Duration() time.Duration {
+	return time.Duration(d.duration)
 }

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -19,6 +19,8 @@ package util
 import (
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestTimeFormatNow(t *testing.T) {
@@ -52,5 +54,23 @@ func TestTimeFormatNow(t *testing.T) {
 				t.Errorf("TimeFormatNow() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	type config struct {
+		Duration Duration `yaml:"duration,omitempty"`
+	}
+
+	configStr := `duration: "1d"`
+	var c config
+	err := yaml.Unmarshal([]byte(configStr), &c)
+	if err != nil {
+		t.Errorf("yaml unmarshal fail, error: %s", err.Error())
+	}
+
+	oneDay, _ := time.ParseDuration("24h")
+	if c.Duration.Duration() != oneDay {
+		t.Errorf("Expected to be equal: %s vs %s", oneDay, c.Duration.Duration())
 	}
 }

--- a/test/benchmark/interceptor/maxbytes_test.go
+++ b/test/benchmark/interceptor/maxbytes_test.go
@@ -1,11 +1,12 @@
 package interceptor
 
 import (
+	"testing"
+
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/source"
 	"github.com/loggie-io/loggie/pkg/interceptor/maxbytes"
-	"testing"
 )
 
 func BenchmarkMaxBytes(b *testing.B) {

--- a/test/benchmark/interceptor/normalizejsondecode_test.go
+++ b/test/benchmark/interceptor/normalizejsondecode_test.go
@@ -1,11 +1,12 @@
 package interceptor
 
 import (
+	"testing"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/interceptor/normalize"
-	"testing"
 )
 
 func BenchmarkJSONDecodeProcess(b *testing.B) {

--- a/test/benchmark/interceptor/normalizeregex_test.go
+++ b/test/benchmark/interceptor/normalizeregex_test.go
@@ -1,11 +1,12 @@
 package interceptor
 
 import (
+	"testing"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/interceptor/normalize"
-	"testing"
 )
 
 func BenchmarkRegexProcess(b *testing.B) {

--- a/test/benchmark/interceptor/normalizesplit_test.go
+++ b/test/benchmark/interceptor/normalizesplit_test.go
@@ -1,11 +1,12 @@
 package interceptor
 
 import (
+	"testing"
+
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/interceptor/normalize"
-	"testing"
 )
 
 func BenchmarkSplitProcess(b *testing.B) {


### PR DESCRIPTION
Feat(source): use model.duration(from github.com/prometheus/common/model) to replace time.duration to support "1d"、"1w" and "1y" time internal for the "ignoreOlder" config of file source

Refactor: sort import(use uber guide: https://github.com/uber-go/guide/blob/master/style.md#import-group-ordering)