### PR TITLE
Fix: optimize merge strategy of default interceptors 

### DIFF
--- a/pkg/core/sysconfig/config.go
+++ b/pkg/core/sysconfig/config.go
@@ -46,6 +46,18 @@ type Defaults struct {
 	Sinks        cfg.CommonCfg   `yaml:"sink"`
 }
 
+var defaultInterceptors = []cfg.CommonCfg{
+	{
+		"type": metric.Type,
+	},
+	{
+		"type": maxbytes.Type,
+	},
+	{
+		"type": retry.Type,
+	},
+}
+
 func (d *Defaults) SetDefaults() {
 	if d.Queue == nil {
 		d.Queue = cfg.CommonCfg{
@@ -53,18 +65,10 @@ func (d *Defaults) SetDefaults() {
 			"name": "default",
 		}
 	}
-	if d.Interceptors == nil || len(d.Interceptors) == 0 {
-		d.Interceptors = []cfg.CommonCfg{
-			{
-				"type": metric.Type,
-			},
-			{
-				"type": maxbytes.Type,
-			},
-			{
-				"type": retry.Type,
-			},
-		}
+	if len(d.Interceptors) == 0 {
+		d.Interceptors = defaultInterceptors
+	} else {
+		d.Interceptors = cfg.MergeCommonCfgListByTypeAndName(d.Interceptors, defaultInterceptors, false, false)
 	}
 }
 

--- a/pkg/eventbus/listener/sink/listener.go
+++ b/pkg/eventbus/listener/sink/listener.go
@@ -176,24 +176,12 @@ func (l *Listener) consumer(e eventbus.SinkMetricData) {
 
 	d, ok := l.data[key]
 	if !ok {
-		data := &data{
+		l.data[key] = &data{
 			PipelineName: e.PipelineName,
 			SourceName:   e.SourceName,
 		}
-		if e.FailEventCount != 0 {
-			data.FailEventCount = int64(e.FailEventCount)
-		}
-		if e.SuccessEventCount != 0 {
-			data.SuccessEventCount = int64(e.SuccessEventCount)
-		}
-		l.data[key] = data
-		return
 	}
 
-	if e.FailEventCount != 0 {
-		d.FailEventCount += int64(e.FailEventCount)
-	}
-	if e.SuccessEventCount != 0 {
-		d.SuccessEventCount += int64(e.SuccessEventCount)
-	}
+	d.SuccessEventCount += int64(e.SuccessEventCount)
+	d.FailEventCount += int64(e.FailEventCount)
 }


### PR DESCRIPTION
merge default interceptors defined in code to default interceptors defined in config