### PR TITLE
Feat: merge defaults configurations support recursion

### DIFF
--- a/pkg/core/cfg/cfg.go
+++ b/pkg/core/cfg/cfg.go
@@ -92,7 +92,15 @@ func MergeCommonCfg(base CommonCfg, from CommonCfg, override bool) CommonCfg {
 	}
 
 	for k, v := range from {
-		_, ok := base[k]
+		baseVal, ok := base[k]
+
+		b, okb := baseVal.(map[interface{}]interface{})
+		f, okf := v.(map[interface{}]interface{})
+		if okb && okf {
+			MergeCommonMap(b, f, override)
+			continue
+		}
+
 		if ok && !override {
 			continue
 		}
@@ -100,6 +108,34 @@ func MergeCommonCfg(base CommonCfg, from CommonCfg, override bool) CommonCfg {
 		base[k] = v
 	}
 	return base
+}
+
+func MergeCommonMap(base map[interface{}]interface{}, from map[interface{}]interface{}, override bool) map[interface{}]interface{} {
+	if base == nil {
+		return from
+	}
+	if from == nil {
+		return base
+	}
+
+	for k, v := range from {
+		baseVal, ok := base[k]
+
+		b, okb := baseVal.(map[interface{}]interface{})
+		f, okf := v.(map[interface{}]interface{})
+		if okb && okf {
+			MergeCommonMap(b, f, override)
+			continue
+		}
+
+		if ok && !override {
+			continue
+		}
+
+		base[k] = v
+	}
+	return base
+
 }
 
 // MergeCommonCfgListByType merge commonCfg list

--- a/pkg/core/cfg/cfg_test.go
+++ b/pkg/core/cfg/cfg_test.go
@@ -304,7 +304,7 @@ func TestMergeCommonCfg(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MergeCommonCfg(tt.args.base, tt.args.from, false); !reflect.DeepEqual(got, tt.want) {
+			if got := MergeCommonCfg(tt.args.base, tt.args.from, true); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MergeCommonCfg() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
#### Proposed Changes:
* merge defaults configurations support recursion

eg:

defaults config:
```yaml
      - type: file
         fields:
           cluster: test1
```
pipeline config:
```yaml
      - type: file
         fields:
           topic: abc
```

**Before:**

merged:
```yaml
      - type: file
         fields:
           topic: abc
```

**After this PR:**

merged:
```yaml
      - type: file
         fields:
           cluster: test1
           topic: abc
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Additional documentation:

None