### PR TITLE
refactor: eventPool get atomicity

### DIFF
--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -19,7 +19,6 @@ package event
 import (
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/loggie-io/loggie/pkg/core/api"
 )
@@ -139,88 +138,3 @@ func (de *DefaultEvent) String() string {
 }
 
 type Factory func() api.Event
-
-type Pool struct {
-	capacity int
-	free     int
-	factory  Factory
-	events   []api.Event
-	lock     *sync.Mutex
-	cond     *sync.Cond
-}
-
-func NewDefaultPool(capacity int) *Pool {
-	return NewPool(capacity, func() api.Event {
-		return newBlankEvent()
-	})
-}
-
-func NewPool(capacity int, factory Factory) *Pool {
-	pool := &Pool{
-		capacity: capacity,
-		free:     capacity,
-		factory:  factory,
-		events:   make([]api.Event, capacity),
-		lock:     &sync.Mutex{},
-	}
-	pool.cond = sync.NewCond(pool.lock)
-
-	for i := 0; i < capacity; i++ {
-		pool.events[i] = pool.factory()
-	}
-	return pool
-}
-
-func (p *Pool) Get() api.Event {
-	p.lock.Lock()
-
-	for p.free == 0 {
-		p.cond.Wait()
-	}
-	p.free--
-	e := p.events[p.free]
-
-	p.lock.Unlock()
-
-	e.Release()
-	return e
-}
-
-func (p *Pool) GetN(n int) []api.Event {
-	es := make([]api.Event, n)
-	p.lock.Lock()
-
-	for i := 0; i < n; i++ {
-		for p.free == 0 {
-			p.cond.Wait()
-		}
-		p.free--
-		e := p.events[p.free]
-		es[i] = e
-	}
-
-	p.lock.Unlock()
-	return es
-}
-
-func (p *Pool) Put(event api.Event) {
-	p.lock.Lock()
-
-	p.events[p.free] = event
-	p.free++
-	p.cond.Signal()
-
-	p.lock.Unlock()
-}
-
-func (p *Pool) PutAll(events []api.Event) {
-	p.lock.Lock()
-
-	for _, e := range events {
-		p.events[p.free] = e
-		p.free++
-	}
-	p.cond.Broadcast()
-
-	p.lock.Unlock()
-}

--- a/pkg/core/event/pool.go
+++ b/pkg/core/event/pool.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2021 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"container/list"
+	"context"
+	"sync"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+)
+
+func NewDefaultPool(capacity int) *Pool {
+	return NewPool(capacity, func() api.Event {
+		return newBlankEvent()
+	})
+}
+
+func NewPool(capacity int, factory Factory) *Pool {
+	pool := &Pool{
+		capacity:     capacity,
+		free:         capacity,
+		factory:      factory,
+		events:       make([]api.Event, capacity),
+		lock:         &sync.Mutex{},
+		requestQueue: list.New(),
+	}
+
+	for i := 0; i < capacity; i++ {
+		pool.events[i] = pool.factory()
+	}
+	return pool
+}
+
+type Pool struct {
+	capacity     int
+	free         int
+	factory      Factory
+	events       []api.Event
+	lock         *sync.Mutex
+	requestQueue *list.List
+}
+
+func (p *Pool) GetNContext(ctx context.Context, n int) ([]api.Event, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if n > p.capacity {
+		panic("out of pool capacity")
+	}
+	p.lock.Lock()
+	var notify request
+	var el *list.Element
+	for {
+		if p.free >= n {
+			if el != nil {
+				p.requestQueue.Remove(el)
+			}
+			break
+		}
+		if notify.C == nil {
+			notify.init(n)
+			el = p.requestQueue.PushBack(&notify)
+		}
+		p.lock.Unlock()
+		select {
+		case <-ctx.Done():
+			p.lock.Lock()
+			p.requestQueue.Remove(el)
+			p.lock.Unlock()
+			return nil, false
+		case <-notify.C:
+		}
+		p.lock.Lock()
+	}
+	p.free -= n
+	events := make([]api.Event, n)
+	copy(events, p.events[p.free:p.free+n])
+	p.notifyAndUnlock()
+	for i := range events {
+		events[i].Release()
+	}
+	return events, true
+}
+
+func (p *Pool) GetN(n int) []api.Event {
+	events, ok := p.GetNContext(context.Background(), n)
+	if !ok {
+		panic("unknown expected GetNContext fail")
+	}
+	return events
+}
+
+func (p *Pool) GetContext(ctx context.Context) (api.Event, bool) {
+	events, ok := p.GetNContext(ctx, 1)
+	if !ok {
+		return nil, false
+	}
+	return events[0], true
+}
+
+func (p *Pool) Get() api.Event {
+	event, ok := p.GetContext(context.Background())
+	if !ok {
+		panic("unknown expected Get fail")
+	}
+	return event
+}
+
+func (p *Pool) notifyAndUnlock() {
+	defer p.lock.Unlock()
+	if p.free == 0 {
+		return
+	}
+	for el := p.requestQueue.Front(); el != nil; el = el.Next() {
+		notify := el.Value.(*request)
+		if p.free >= notify.N {
+			select {
+			case notify.C <- struct{}{}:
+				break
+			default:
+			}
+		}
+	}
+
+}
+
+// Put release events to the pool.
+func (p *Pool) Put(events ...api.Event) {
+	p.lock.Lock()
+	if p.free+len(events) > len(p.events) {
+		panic("unknown expected event put")
+	}
+	copy(p.events[p.free:], events)
+	p.free += len(events)
+	p.notifyAndUnlock()
+}
+
+// PutAll release events to the pool.
+// Deprecated: Use Put instead
+func (p *Pool) PutAll(events []api.Event) {
+	p.Put(events...)
+}
+
+type request struct {
+	C chan struct{}
+	N int
+}
+
+func (r *request) init(n int) {
+	r.C = make(chan struct{})
+	r.N = n
+}

--- a/pkg/core/event/pool_test.go
+++ b/pkg/core/event/pool_test.go
@@ -1,0 +1,150 @@
+package event
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+)
+
+func TestGetAndPut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	const capacity = 10
+
+	p := NewDefaultPool(capacity)
+
+	// GetContext
+	{
+		var events []api.Event
+		for i := 0; i < 10; i++ {
+			event, ok := p.GetContext(ctx)
+			if !ok {
+				t.Fatal("GetContext failed")
+			}
+			events = append(events, event)
+		}
+		p.Put(events...)
+	}
+	// Get
+	{
+		var events []api.Event
+		for i := 0; i < 10; i++ {
+			event := p.Get()
+			events = append(events, event)
+		}
+		p.Put(events...)
+	}
+	// GetNContext
+	{
+		events1, ok := p.GetNContext(ctx, capacity/2)
+		if !ok {
+			t.Fatal("GetNContext failed")
+		}
+		events2, ok := p.GetNContext(ctx, capacity/2)
+		if !ok {
+			t.Fatal("GetNContext failed")
+		}
+		p.Put(events1...)
+		p.Put(events2...)
+	}
+	// GetN
+	{
+		events1 := p.GetN(capacity / 2)
+		events2 := p.GetN(capacity / 2)
+		p.Put(events1...)
+		p.Put(events2...)
+	}
+}
+
+func TestParallelGetAndPut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	p := NewDefaultPool(10)
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			es, ok := p.GetNContext(ctx, 3)
+			if !ok {
+				t.Errorf("GetNContext failed")
+			}
+			time.Sleep(time.Millisecond)
+			p.Put(es...)
+			wg.Done()
+		}()
+
+	}
+	wg.Wait()
+}
+
+func TestGetWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := NewDefaultPool(10)
+
+	events := p.GetN(10)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		_, ok := p.GetNContext(ctx, 9)
+		if ok {
+			t.Errorf("GetNContext abnormal")
+		}
+		wg.Done()
+	}()
+	p.Put(events[0])
+	p.Put(events[1])
+	p.Put(events[2])
+	p.Put(events[3])
+	p.Put(events[4])
+	cancel()
+	wg.Wait()
+}
+
+func benchmarkPoolIO(b *testing.B, poolCapacity, parallel, batchSize int) {
+	b.StopTimer()
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	ch := make(chan []api.Event)
+	p := NewDefaultPool(poolCapacity)
+
+	wg.Add(parallel)
+	for i := 0; i < parallel; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				events, ok := p.GetNContext(ctx, batchSize)
+				if !ok {
+					return
+				}
+				select {
+				case <-ctx.Done():
+				case ch <- events:
+				}
+			}
+		}()
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		events := <-ch
+		p.Put(events...)
+	}
+	b.StopTimer()
+	cancel()
+	wg.Wait()
+}
+
+func BenchmarkPoolIO(b *testing.B) {
+	const batchSize = 1024
+	for i := 0; i < 10; i++ {
+		parallel := 1 << (i + 1)
+		b.Run(fmt.Sprintf("BenchmarkPoolIO%d", parallel), func(b *testing.B) {
+			poolCapacity := batchSize * (parallel/2 + 1)
+			benchmarkPoolIO(b, poolCapacity, parallel, batchSize)
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes:

当前 eventPool 实现在并发调用 GetN 时会导致死锁问题见 [#228](https://github.com/loggie-io/loggie/issues/228#issuecomment-1141773242) 。

重构了 eventPool 实现主要变更：

* 解决并发调用 GetN 导致死锁的问题
* eventPool 所有 Get API 支持 context.Context 支持由调用方终止阻塞等待