### PR TITLE
Feat: support extra labels in prometheusExporter source

### DIFF
--- a/cmd/loggie/main.go
+++ b/cmd/loggie/main.go
@@ -59,12 +59,12 @@ func init() {
 
 func main() {
 	flag.Parse()
+	// init logging configuration
 	log.InitDefaultLogger()
 
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 
-	// init logging configuration
 	// Automatically set GOMAXPROCS to match Linux container CPU quota
 	if _, err := maxprocs.Set(maxprocs.Logger(log.Debug)); err != nil {
 		log.Fatal("set maxprocs error: %v", err)

--- a/pkg/source/prometheus_exporter/config.go
+++ b/pkg/source/prometheus_exporter/config.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Config struct {
-	Endpoints []string      `yaml:"endpoints,omitempty" validate:"required"`
-	Interval  time.Duration `yaml:"interval,omitempty" default:"30s"`
-	Timeout   time.Duration `yaml:"timeout,omitempty" default:"5s"`
-	ToJson    bool          `yaml:"toJson,omitempty"`
+	Endpoints []string          `yaml:"endpoints,omitempty" validate:"required"`
+	Interval  time.Duration     `yaml:"interval,omitempty" default:"30s"`
+	Timeout   time.Duration     `yaml:"timeout,omitempty" default:"5s"`
+	ToJson    bool              `yaml:"toJson,omitempty"`
+	Labels    map[string]string `yaml:"labels,omitempty"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
#### Proposed Changes:

* add `labels` fields in prometheusExporter source

eg:
```
[{
	"name": "go_memstats_mspan_inuse_bytes",
	"help": "Number of bytes in use by mspan structures.",
	"type": "GAUGE",
	"metrics": [{
		"labels": {
			"cluster": "test01"
		},
		"timestamp_ms": "1654070479686",
		"value": "133144"
	}]
},...]
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Additional documentation:

- [ ] TODO