### PR TITLE
Feat: use local time format in pattern fields

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -37,7 +37,7 @@ const (
 func TimeFormatNow(pattern string) string {
 	replacer := strings.NewReplacer(year, stdYear, month, stdMonth, day, stdDay, hour, stdHour)
 	layout := replacer.Replace(pattern)
-	return time.Now().Format(layout)
+	return time.Now().Local().Format(layout)
 }
 
 func UnixMilli(t time.Time) int64 {


### PR DESCRIPTION
#### Proposed Changes:

* use local time in TimeFormatNow

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Additional documentation:

None