### PR TITLE
Feat: logconfig/clusterlogconfig labelSelector support wildcard *

### DIFF
--- a/pkg/discovery/kubernetes/controller/controller.go
+++ b/pkg/discovery/kubernetes/controller/controller.go
@@ -444,12 +444,12 @@ func (c *Controller) syncHandler(element Element) error {
 
 	case EventClusterLogConf:
 		if err = c.reconcileClusterLogConfig(element); err != nil {
-			log.Warn("reconcile logConfig %s err: %+v", element.Key, err)
+			log.Warn("reconcile logConfig %s err: %v", element.Key, err)
 		}
 
 	case EventLogConf:
 		if err = c.reconcileLogConfig(element); err != nil {
-			log.Warn("reconcile logConfig %s err: %+v", element.Key, err)
+			log.Warn("reconcile logConfig %s err: %v", element.Key, err)
 		}
 
 	case EventNode:

--- a/pkg/discovery/kubernetes/controller/reconcile.go
+++ b/pkg/discovery/kubernetes/controller/reconcile.go
@@ -240,6 +240,7 @@ func (c *Controller) reconcileLogConfigAddOrUpdate(lgc *logconfigv1beta1.LogConf
 }
 
 func (c *Controller) handleAllTypesAddOrUpdate(lgc *logconfigv1beta1.LogConfig) (err error, keys []string) {
+	lgc = lgc.DeepCopy()
 	switch lgc.Spec.Selector.Type {
 	case logconfigv1beta1.SelectorTypePod:
 		return c.handleLogConfigTypePodAddOrUpdate(lgc)

--- a/pkg/discovery/kubernetes/controller/reconcile.go
+++ b/pkg/discovery/kubernetes/controller/reconcile.go
@@ -55,13 +55,11 @@ func (c *Controller) reconcileClusterLogConfig(element Element) error {
 	}
 
 	err, keys := c.reconcileClusterLogConfigAddOrUpdate(clusterLogConfig)
-	if err != nil {
-		msg := fmt.Sprintf(MessageSyncFailed, clusterLogConfig.Spec.Selector.Type, keys, err.Error())
-		c.record.Event(clusterLogConfig, corev1.EventTypeWarning, ReasonFailed, msg)
-	} else if len(keys) != 0 {
+	if len(keys) > 0 {
 		msg := fmt.Sprintf(MessageSyncSuccess, clusterLogConfig.Spec.Selector.Type, keys)
 		c.record.Event(clusterLogConfig, corev1.EventTypeNormal, ReasonSuccess, msg)
 	}
+	// no need to record failed event here because we recorded events when received pod create/update
 	return err
 }
 
@@ -82,10 +80,7 @@ func (c *Controller) reconcileLogConfig(element Element) error {
 	}
 
 	err, keys := c.reconcileLogConfigAddOrUpdate(logConf)
-	if err != nil {
-		msg := fmt.Sprintf(MessageSyncFailed, logConf.Spec.Selector.Type, keys, err.Error())
-		c.record.Event(logConf, corev1.EventTypeWarning, ReasonFailed, msg)
-	} else if len(keys) != 0 {
+	if len(keys) > 0 {
 		msg := fmt.Sprintf(MessageSyncSuccess, logConf.Spec.Selector.Type, keys)
 		c.record.Event(logConf, corev1.EventTypeNormal, ReasonSuccess, msg)
 	}

--- a/pkg/discovery/kubernetes/controller/selectpodhandler.go
+++ b/pkg/discovery/kubernetes/controller/selectpodhandler.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	GenerateConfigName           = "kube-loggie.yml"
-	GenerateTypeLoggieConfigName = "loggie-config.yml"
+	GenerateTypeLoggieConfigName = "cluster-config.yml"
 	GenerateTypeNodeConfigName   = "node-config.yml"
 )
 
@@ -157,7 +157,6 @@ func (c *Controller) handlePodAddOrUpdateOfLogConfig(pod *corev1.Pod) {
 	}
 
 	for _, lgc := range lgcList {
-
 		if !c.belongOfCluster(lgc.Spec.Selector.Cluster) {
 			continue
 		}

--- a/pkg/discovery/kubernetes/controller/selectpodhandler.go
+++ b/pkg/discovery/kubernetes/controller/selectpodhandler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/loggie-io/loggie/pkg/source/codec/json"
 	"github.com/loggie-io/loggie/pkg/source/codec/regex"
 	k8sMeta "github.com/loggie-io/loggie/pkg/util/pattern/k8smeta"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"regexp"
 	"strings"
 
@@ -123,15 +124,19 @@ func (c *Controller) handleLogConfigTypePodAddOrUpdate(lgc *logconfigv1beta1.Log
 		return nil, nil
 	}
 
-	var ret []string
+	var successPodNames []string
+	var errs []error
 	for _, pod := range podList {
 		if err := c.handleLogConfigPerPod(lgc, pod); err != nil {
-			return err, []string{pod.Name}
+			errs = append(errs, errors.WithMessagef(err, "match pod %s/%s", pod.Namespace, pod.Name))
+			continue
 		}
-		ret = append(ret, pod.Name)
+		successPodNames = append(successPodNames, pod.Name)
 	}
-
-	return nil, ret
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs), successPodNames
+	}
+	return nil, successPodNames
 }
 
 func (c *Controller) handlePodAddOrUpdate(pod *corev1.Pod) error {

--- a/pkg/discovery/kubernetes/helper/kube_test.go
+++ b/pkg/discovery/kubernetes/helper/kube_test.go
@@ -1,0 +1,75 @@
+package helper
+
+import "testing"
+
+func TestLabelsSubset(t *testing.T) {
+	type args struct {
+		i map[string]string
+		j map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "is subset",
+			args: args{
+				i: map[string]string{
+					"a": "b",
+				},
+				j: map[string]string{
+					"a": "b",
+					"c": "d",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "is not subset",
+			args: args{
+				i: map[string]string{
+					"a": "b",
+					"c": "d",
+				},
+				j: map[string]string{
+					"a": "b",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "include wildcard *",
+			args: args{
+				i: map[string]string{
+					"a": MatchAllToken,
+				},
+				j: map[string]string{
+					"a": "b",
+					"c": "d",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "wildcard * not working",
+			args: args{
+				i: map[string]string{
+					"a": MatchAllToken,
+				},
+				j: map[string]string{
+					"c":   "d",
+					"foo": "bar",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LabelsSubset(tt.args.i, tt.args.j); got != tt.want {
+				t.Errorf("LabelsSubset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes:

* logconfig/clusterlogconfig labelSelector support wildcard *

```
spec:
  selector:
    type: pod
    labelSelector:
      app: *
```

* support override annotation `logconfig.loggie.io/override` or `clusterlogconfig.loggie.io/override` in logconfig/clusterLogconfig
```
apiVersion: loggie.io/v1beta1
kind: LogConfig
metadata:
  annotations:
    clusterlogconfig.loggie.io/override: common
  name: nginx
  ...
```
this nginx logConfig would override the common clusterLogconfig by the matched pod.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

#### Additional documentation:

- [ ] TODO