### PR TITLE
fix addonMeta panic

### DIFF
--- a/pkg/core/event/event.go
+++ b/pkg/core/event/event.go
@@ -97,6 +97,10 @@ func (de *DefaultEvent) Meta() api.Meta {
 }
 
 func (de *DefaultEvent) Header() map[string]interface{} {
+	if de.H == nil {
+		de.H = make(map[string]interface{})
+	}
+
 	return de.H
 }
 


### PR DESCRIPTION
fix addonMeta panic 

```
panic: assignment to entry in nil map

goroutine 57 [running]:
github.com/loggie-io/loggie/pkg/source/file.addonMetaProductFunc.func1({0x24a6848, 0xc000764f90})
	/pkg/source/file/source.go:223 +0x3bf
github.com/loggie-io/loggie/pkg/source/codec.glob..func1.1({0x24a6848, 0xc000764f90})
	/pkg/source/codec/codec.go:64 +0xa2
github.com/loggie-io/loggie/pkg/source/file.(*Job).ProductEvent(0xc00083e000, 0x29872, {0x10000, 0xc00052d769, 0x366d3c0}, {0xc0004f2000, 0x5b, 0x4d025e})
	/pkg/source/file/job.go:345 +0x7a6
github.com/loggie-io/loggie/pkg/source/file/process.(*LineProcessor).Process(0x10000, {0x10000, 0x100000000000c93}, 0xc0003eb4a0)
	/pkg/source/file/process/line.go:52 +0x1c7
github.com/loggie-io/loggie/pkg/source/file.NewProcessChain.func2(0xc00007a070)
	/pkg/source/file/process.go:139 +0x33
github.com/loggie-io/loggie/pkg/source/file.(*abstractProcessChain).Process(0x0, 0x0)
	/pkg/source/file/process.go:67 +0x1f
github.com/loggie-io/loggie/pkg/source/file/process.(*SourceProcessor).Process(0xc0008a6c30, {0x2448b20, 0xc000532248}, 0xc0003eb4a0)
	/pkg/source/file/process/source.go:50 +0x109
github.com/loggie-io/loggie/pkg/source/file.NewProcessChain.func2(0x4c2937)
	/pkg/source/file/process.go:139 +0x33
github.com/loggie-io/loggie/pkg/source/file.(*abstractProcessChain).Process(0x4d24e0, 0xc0003eae40)
	/pkg/source/file/process.go:67 +0x1f
github.com/loggie-io/loggie/pkg/source/file/process.(*LoopProcessor).Process(0xc0004e63f0, {0x2448b20, 0xc000532250}, 0xc0003eb4a0)
	/pkg/source/file/process/loop.go:40 +0x73
github.com/loggie-io/loggie/pkg/source/file.NewProcessChain.func2(0xc0008a6cf0)
	/pkg/source/file/process.go:139 +0x33
github.com/loggie-io/loggie/pkg/source/file.(*abstractProcessChain).Process(0x203000, 0x203000)
	/pkg/source/file/process.go:67 +0x1f
github.com/loggie-io/loggie/pkg/source/file/process.(*LastLineProcessor).Process(0xc000458790, {0x2448b20, 0xc000532258}, 0xc0003eb4a0)
	/pkg/source/file/process/lastline.go:36 +0x5a
github.com/loggie-io/loggie/pkg/source/file.NewProcessChain.func2(0x29817)
	/pkg/source/file/process.go:139 +0x33
github.com/loggie-io/loggie/pkg/source/file.(*abstractProcessChain).Process(0xc00083e000, 0xc0004f2000)
	/pkg/source/file/process.go:67 +0x1f
github.com/loggie-io/loggie/pkg/source/file.(*Reader).work(0xc00076c3c0, 0x0)
	/pkg/source/file/read.go:124 +0x2a7
created by github.com/loggie-io/loggie/pkg/source/file.(*Reader).Start.func1
	/pkg/source/file/read.go:98 +0x2f
```