### PR TITLE
fix: cannot rename fields which containing '.'

### DIFF
--- a/pkg/interceptor/normalize/rename.go
+++ b/pkg/interceptor/normalize/rename.go
@@ -77,20 +77,20 @@ func (r *MoveProcessor) Process(e api.Event) error {
 			e.Fill(e.Meta(), e.Header(), []byte{})
 			continue
 		}
-		val1 := obj.GetPath(from)
-		val2 := obj.Get(from)
-		if val1.IsNull() && val2.IsNull() {
-			log.Info("move fields from %s is not exist", from)
-			log.Debug("move event: %s", e.String())
+		valGetPath := obj.GetPath(from)
+		if !valGetPath.IsNull() {
+			obj.GetPath(from)
+			obj.SetPath(convert.To, valGetPath.Value())
 			continue
 		}
-		if !val1.IsNull() {
-			obj.GetPath(from)
-			obj.SetPath(convert.To, val1.Value())
-		} else {
+		valGet := obj.Get(from)
+		if !valGet.IsNull() {
 			obj.Del(from)
-			obj.Set(convert.To, val2.Value())
+			obj.Set(convert.To, valGet.Value())
+			continue
 		}
+		log.Info("move fields from %s is not exist", from)
+		log.Debug("move event: %s", e.String())
 	}
 
 	return nil

--- a/pkg/interceptor/normalize/rename.go
+++ b/pkg/interceptor/normalize/rename.go
@@ -77,14 +77,14 @@ func (r *MoveProcessor) Process(e api.Event) error {
 			e.Fill(e.Meta(), e.Header(), []byte{})
 			continue
 		}
-		val := obj.GetPath(from)
+		val := obj.Get(from)
 		if val.IsNull() {
 			log.Info("move fields from %s is not exist", from)
 			log.Debug("move event: %s", e.String())
 			continue
 		}
-		obj.DelPath(from)
-		obj.SetPath(convert.To, val.Value())
+		obj.Del(from)
+		obj.Set(convert.To, val.Value())
 	}
 
 	return nil

--- a/pkg/interceptor/normalize/rename.go
+++ b/pkg/interceptor/normalize/rename.go
@@ -77,14 +77,20 @@ func (r *MoveProcessor) Process(e api.Event) error {
 			e.Fill(e.Meta(), e.Header(), []byte{})
 			continue
 		}
-		val := obj.Get(from)
-		if val.IsNull() {
+		val1 := obj.GetPath(from)
+		val2 := obj.Get(from)
+		if val1.IsNull() && val2.IsNull() {
 			log.Info("move fields from %s is not exist", from)
 			log.Debug("move event: %s", e.String())
 			continue
 		}
-		obj.Del(from)
-		obj.Set(convert.To, val.Value())
+		if !val1.IsNull() {
+			obj.GetPath(from)
+			obj.SetPath(convert.To, val1.Value())
+		} else {
+			obj.Del(from)
+			obj.Set(convert.To, val2.Value())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
if obj.GetPath not found use obj.Get

Which issue(s) this PR fixes:
Fixes https://github.com/loggie-io/loggie/issues/295