### PR TITLE
Fix: support [a.b] when fields key is a.b other than a nested fields

### DIFF
--- a/pkg/util/eventops/event_test.go
+++ b/pkg/util/eventops/event_test.go
@@ -33,6 +33,18 @@ func TestGet(t *testing.T) {
 			want: "foo",
 		},
 		{
+			name: "get a.[b.c]",
+			args: args{
+				e: event.NewEvent(map[string]interface{}{
+					"a": map[string]interface{}{
+						"b.c": "foo",
+					},
+				}, []byte("this is body")),
+				key: "a.[b.c]",
+			},
+			want: "foo",
+		},
+		{
 			name: "get nil",
 			args: args{
 				e: event.NewEvent(map[string]interface{}{
@@ -331,6 +343,23 @@ func TestMove(t *testing.T) {
 			want: event.NewEvent(map[string]interface{}{
 				"a": map[string]interface{}{},
 				"c": map[string]interface{}{
+					"d": "foo",
+				},
+			}, []byte("this is body")),
+		},
+		{
+			name: "move a.[b.c] to a.d",
+			args: args{
+				e: event.NewEvent(map[string]interface{}{
+					"a": map[string]interface{}{
+						"b.c": "foo",
+					},
+				}, []byte("this is body")),
+				from: "a.[b.c]",
+				to:   "a.d",
+			},
+			want: event.NewEvent(map[string]interface{}{
+				"a": map[string]interface{}{
 					"d": "foo",
 				},
 			}, []byte("this is body")),

--- a/pkg/util/runtime/object.go
+++ b/pkg/util/runtime/object.go
@@ -22,8 +22,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const sep = "."
-
 type Object struct {
 	data interface{}
 }

--- a/pkg/util/runtime/select.go
+++ b/pkg/util/runtime/select.go
@@ -20,13 +20,41 @@ import (
 	"strings"
 )
 
+const (
+	sep          = '.'
+	connectStart = '['
+	connectEnd   = ']'
+)
+
 func GetQueryPaths(query string) []string {
-	paths := strings.Split(query, sep)
-	return paths
+	var result []string
+	var sb strings.Builder
+	connectorMode := false
+	for _, s := range query {
+		if s == sep && !connectorMode {
+			result = append(result, sb.String())
+			sb.Reset()
+			continue
+
+		} else if s == connectStart {
+			connectorMode = true
+			continue
+
+		} else if s == connectEnd {
+			connectorMode = false
+			continue
+		}
+
+		// add sub string
+		sb.WriteRune(s)
+	}
+
+	result = append(result, sb.String())
+	return result
 }
 
 func GetQueryUpperPaths(query string) ([]string, string) {
-	paths := strings.Split(query, sep)
+	paths := GetQueryPaths(query)
 	if len(paths) < 2 {
 		return []string{}, query
 	}

--- a/pkg/util/runtime/select_test.go
+++ b/pkg/util/runtime/select_test.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetQueryPaths(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "normal",
+			args: args{
+				query: `a.b`,
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "a.b.c",
+			args: args{
+				query: `a.b.c`,
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "[a.b].c",
+			args: args{
+				query: `[a.b].c`,
+			},
+			want: []string{"a.b", "c"},
+		},
+		{
+			name: "a.[b.c]",
+			args: args{
+				query: `a.[b.c]`,
+			},
+			want: []string{"a", "b.c"},
+		},
+		{
+			name: "a.[b.c].d",
+			args: args{
+				query: `a.[b.c].d`,
+			},
+			want: []string{"a", "b.c", "d"},
+		},
+		{
+			name: "[a.b].c.[d.e]",
+			args: args{
+				query: `[a.b].c.[d.e]`,
+			},
+			want: []string{"a.b", "c", "d.e"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetQueryPaths(tt.args.query)
+			assert.Equal(t, got, tt.want)
+		})
+	}
+}
+
+func TestGetQueryUpperPaths(t *testing.T) {
+	type args struct {
+		query string
+	}
+	type want struct {
+		before []string
+		last   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "normal",
+			args: args{
+				query: "a.b.c",
+			},
+			want: want{
+				before: []string{"a", "b"},
+				last:   "c",
+			},
+		},
+		{
+			name: "[a.b].c",
+			args: args{
+				query: "[a.b].c",
+			},
+			want: want{
+				before: []string{"a.b"},
+				last:   "c",
+			},
+		},
+		{
+			name: "a.[b.c]",
+			args: args{
+				query: "a.[b.c].d",
+			},
+			want: want{
+				before: []string{"a", "b.c"},
+				last:   "d",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before, last := GetQueryUpperPaths(tt.args.query)
+			assert.Equal(t, before, tt.want.before)
+			assert.Equal(t, last, tt.want.last)
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes:

* support [a.b] when fields key is a.b other than a nested fields

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None
#### Additional documentation:

- [ ] TODO