### PR TITLE
Fix empty fields after the field is renamed in normalize interceptor

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -710,6 +710,11 @@ func addSourceFields(header map[string]interface{}, config source.Config) {
 		}
 		return
 	}
+	tmp := make(map[string]interface{})
+	for k, v := range sourceFields {
+		tmp[k] = v
+	}
+	sourceFields = tmp
 	sourceFieldsKey := config.FieldsUnderKey
 	if originFields, exist := header[sourceFieldsKey]; exist {
 		if originFieldsMap, convert := originFields.(map[string]interface{}); convert {


### PR DESCRIPTION
修复字段被rename后导致后续数据无fields的问题