### PR TITLE
Feat: add schema interceptor

### DIFF
--- a/pkg/include/include.go
+++ b/pkg/include/include.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/loggie-io/loggie/pkg/interceptor/metric"
 	_ "github.com/loggie-io/loggie/pkg/interceptor/normalize"
 	_ "github.com/loggie-io/loggie/pkg/interceptor/retry"
+	_ "github.com/loggie-io/loggie/pkg/interceptor/schema"
 	_ "github.com/loggie-io/loggie/pkg/interceptor/transformer"
 	_ "github.com/loggie-io/loggie/pkg/interceptor/transformer/action"
 	_ "github.com/loggie-io/loggie/pkg/interceptor/transformer/condition"

--- a/pkg/interceptor/schema/config.go
+++ b/pkg/interceptor/schema/config.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import "github.com/loggie-io/loggie/pkg/core/interceptor"
+
+type Config struct {
+	interceptor.ExtensionConfig `yaml:",inline"`
+
+	// AddMeta add system metadata to the event
+	AddMeta *AddMetaConfig `yaml:"addMeta,omitempty"`
+
+	Remap map[string]Remap `yaml:"remap,omitempty"`
+}
+
+type AddMetaConfig struct {
+	Timestamp    TimestampRemap `yaml:"timestamp,omitempty"`
+	PipelineName Remap          `yaml:"pipelineName,omitempty"`
+	SourceName   Remap          `yaml:"sourceName,omitempty"`
+}
+
+type Remap struct {
+	Key string `yaml:"key,omitempty"`
+}
+
+type TimestampRemap struct {
+	Key      string `yaml:"key,omitempty"`
+	Location string `yaml:"location,omitempty"`
+	Layout   string `yaml:"layout,omitempty"`
+}

--- a/pkg/interceptor/schema/interceptor.go
+++ b/pkg/interceptor/schema/interceptor.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"fmt"
+	eventer "github.com/loggie-io/loggie/pkg/core/event"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/loggie-io/loggie/pkg/util/eventops"
+	timeutil "github.com/loggie-io/loggie/pkg/util/time"
+	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/source"
+	"github.com/loggie-io/loggie/pkg/pipeline"
+)
+
+const (
+	Type = "schema"
+
+	defaultTsLayout = "2006-01-02T15:04:05.000Z"
+)
+
+func init() {
+	pipeline.Register(api.INTERCEPTOR, Type, makeInterceptor)
+}
+
+func makeInterceptor(info pipeline.Info) api.Component {
+	return &Interceptor{
+		config: &Config{},
+	}
+}
+
+type Interceptor struct {
+	config *Config
+}
+
+func (icp *Interceptor) Config() interface{} {
+	return icp.config
+}
+
+func (icp *Interceptor) Category() api.Category {
+	return api.INTERCEPTOR
+}
+
+func (icp *Interceptor) Type() api.Type {
+	return Type
+}
+
+func (icp *Interceptor) String() string {
+	return fmt.Sprintf("%s/%s", icp.Category(), icp.Type())
+}
+
+func (icp *Interceptor) Init(context api.Context) error {
+	return nil
+}
+
+func (icp *Interceptor) Start() error {
+	return nil
+}
+
+func (icp *Interceptor) Stop() {
+}
+
+func (icp *Interceptor) Intercept(invoker source.Invoker, invocation source.Invocation) api.Result {
+	event := invocation.Event
+	header := event.Header()
+
+	if icp.config.AddMeta != nil {
+		addMetaTimestamp(header, event.Meta(), icp.config)
+		addMetaPipelineName(header, event.Meta(), icp.config)
+		addMetaSourceName(header, event.Meta(), icp.config)
+	}
+
+	if len(icp.config.Remap) > 0 {
+		remap(event, icp.config)
+	}
+
+	return invoker.Invoke(invocation)
+}
+
+func addMetaTimestamp(header map[string]interface{}, meta api.Meta, config *Config) {
+	conf := config.AddMeta.Timestamp
+	if conf.Key == "" {
+		return
+	}
+
+	timestamp, exist := meta.Get(eventer.SystemProductTimeKey)
+	if !exist {
+		return
+	}
+
+	t, ok := timestamp.(time.Time)
+	if !ok {
+		return
+	}
+
+	layout := conf.Layout
+	if layout == "" {
+		layout = defaultTsLayout
+	}
+
+	// conf.Location could be "" or "UTC" or "Local"
+	// default "" indicate "UTC"
+	out, err := timeutil.Format(t, conf.Location, layout)
+	if err != nil {
+		log.Warn("time format system product timestamp err: %+v", err)
+		return
+	}
+	header[conf.Key] = out
+}
+
+func addMetaPipelineName(header map[string]interface{}, meta api.Meta, config *Config) {
+	if config.AddMeta.PipelineName.Key == "" {
+		return
+	}
+
+	pipelineName, exist := meta.Get(eventer.SystemPipelineKey)
+	if !exist {
+		return
+	}
+
+	header[config.AddMeta.PipelineName.Key] = pipelineName
+}
+
+func addMetaSourceName(header map[string]interface{}, meta api.Meta, config *Config) {
+	if config.AddMeta.SourceName.Key == "" {
+		return
+	}
+
+	sourceName, exist := meta.Get(eventer.SystemSourceKey)
+	if !exist {
+		return
+	}
+
+	header[config.AddMeta.SourceName.Key] = sourceName
+}
+
+func remap(event api.Event, config *Config) {
+	for k, v := range config.Remap {
+		eventops.Move(event, k, v.Key)
+	}
+}
+
+func (icp *Interceptor) Order() int {
+	return icp.config.Order
+}
+
+func (icp *Interceptor) BelongTo() (componentTypes []string) {
+	return icp.config.BelongTo
+}
+
+func (icp *Interceptor) IgnoreRetry() bool {
+	return true
+}

--- a/pkg/interceptor/schema/pipeline.yml
+++ b/pkg/interceptor/schema/pipeline.yml
@@ -1,0 +1,25 @@
+---
+## add timestamp fields
+## rename body to message
+interceptors:
+  - type: schema
+    addMeta:
+      timestamp:
+        key: "@timestamp"
+    remap:
+      body:
+        key: message
+
+---
+## with location: "" or UTC, Local ...
+## with golang style layout: 2006-01-02T15:04:05Z07:00(RFC3339) ...
+interceptors:
+  - type: schema
+    addMeta:
+      timestamp:
+        key: "_timestamp_"
+        location: Local
+        layout: 2006-01-02T15:04:05Z07:00
+    remap:
+      body:
+        key: _log_

--- a/pkg/interceptor/transformer/action/timestamp.go
+++ b/pkg/interceptor/transformer/action/timestamp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/util/eventops"
+	timeutil "github.com/loggie-io/loggie/pkg/util/time"
 	"github.com/pkg/errors"
 	"strconv"
 	"time"
@@ -74,7 +75,7 @@ func (t *Timestamp) act(e api.Event) error {
 	fromVal := eventops.GetString(e, t.key)
 
 	// parse time
-	var timestamp = time.Time{}
+	var timestamp time.Time
 	switch extra.FromLayout {
 	case LayoutUnix:
 		i, err := strconv.ParseInt(fromVal, 10, 64)
@@ -102,26 +103,14 @@ func (t *Timestamp) act(e api.Event) error {
 			return errors.WithMessagef(err, "parse timestamp with layout %s from field %s error", extra.FromLayout, t.key)
 		}
 		timestamp = fromTime
-
 	}
 
 	// format time
-	toLocation, err := time.LoadLocation(extra.ToLocation)
+	out, err := timeutil.Format(timestamp, extra.ToLocation, extra.ToLayout)
 	if err != nil {
-		return errors.WithMessagef(err, "load location %s from field %s error", extra.FromLocation, t.key)
+		return err
 	}
-	timestamp = timestamp.In(toLocation)
-
-	switch extra.ToLayout {
-	case LayoutUnix:
-		eventops.Set(e, t.key, timestamp.Unix())
-
-	case LayoutUnixMs:
-		eventops.Set(e, t.key, timestamp.UnixMilli())
-
-	default:
-		eventops.Set(e, t.key, timestamp.Format(extra.ToLayout))
-	}
+	eventops.Set(e, t.key, out)
 
 	return nil
 }

--- a/pkg/source/file/config.go
+++ b/pkg/source/file/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package file
 
 import (
+	timeutil "github.com/loggie-io/loggie/pkg/util/time"
 	"os"
 	"regexp"
 	"time"
@@ -36,14 +37,14 @@ type Config struct {
 }
 
 type CollectConfig struct {
-	IsolationLevel           string        `yaml:"isolationLevel,omitempty" default:"share"`
-	Paths                    []string      `yaml:"paths,omitempty" validate:"required"` // glob pattern
-	ExcludeFiles             []string      `yaml:"excludeFiles,omitempty"`              // regular pattern
-	IgnoreOlder              util.Duration `yaml:"ignoreOlder,omitempty"`
-	IgnoreSymlink            bool          `yaml:"ignoreSymlink,omitempty" default:"false"`
-	RereadTruncated          bool          `yaml:"rereadTruncated,omitempty" default:"true"`                           // Read from the beginning when the file is truncated
-	FirstNBytesForIdentifier int           `yaml:"firstNBytesForIdentifier,omitempty" default:"128" validate:"gte=10"` // If the file size is smaller than `firstNBytesForIdentifier`, it will not be collected
-	AddonMeta                bool          `yaml:"addonMeta,omitempty"`
+	IsolationLevel           string            `yaml:"isolationLevel,omitempty" default:"share"`
+	Paths                    []string          `yaml:"paths,omitempty" validate:"required"` // glob pattern
+	ExcludeFiles             []string          `yaml:"excludeFiles,omitempty"`              // regular pattern
+	IgnoreOlder              timeutil.Duration `yaml:"ignoreOlder,omitempty"`
+	IgnoreSymlink            bool              `yaml:"ignoreSymlink,omitempty" default:"false"`
+	RereadTruncated          bool              `yaml:"rereadTruncated,omitempty" default:"true"`                           // Read from the beginning when the file is truncated
+	FirstNBytesForIdentifier int               `yaml:"firstNBytesForIdentifier,omitempty" default:"128" validate:"gte=10"` // If the file size is smaller than `firstNBytesForIdentifier`, it will not be collected
+	AddonMeta                bool              `yaml:"addonMeta,omitempty"`
 	excludeFilePatterns      []*regexp.Regexp
 }
 

--- a/pkg/source/prometheus_exporter/prometheus.go
+++ b/pkg/source/prometheus_exporter/prometheus.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/loggie-io/loggie/pkg/util/pattern"
+	timeutil "github.com/loggie-io/loggie/pkg/util/time"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/loggie-io/loggie/pkg/core/event"
 	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/pipeline"
-	"github.com/loggie-io/loggie/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/prom2json"
@@ -180,7 +180,7 @@ func (e *PromExporter) promToJson(in io.Reader) ([]byte, error) {
 	for _, val := range metricFamilies {
 		// add timestamp in metrics
 		for _, m := range val.Metric {
-			timeMs := util.UnixMilli(time.Now())
+			timeMs := timeutil.UnixMilli(time.Now())
 			m.TimestampMs = &timeMs
 		}
 

--- a/pkg/util/pattern/pattern.go
+++ b/pkg/util/pattern/pattern.go
@@ -17,9 +17,9 @@ limitations under the License.
 package pattern
 
 import (
-	"github.com/loggie-io/loggie/pkg/util"
 	k8sMeta "github.com/loggie-io/loggie/pkg/util/pattern/k8smeta"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
+	"github.com/loggie-io/loggie/pkg/util/time"
 	"os"
 	"regexp"
 	"strings"
@@ -68,7 +68,7 @@ func isTimeVar(key string) bool {
 	return strings.HasPrefix(key, timeToken)
 }
 func timeMatcherRender(key string) string {
-	return util.TimeFormatNow(strings.TrimLeft(key, timeToken))
+	return time.TimeFormatNow(strings.TrimLeft(key, timeToken))
 }
 
 // ObjectMatcher retrieve any fields from events, e.g. ${a.b}

--- a/pkg/util/pattern/pattern_test.go
+++ b/pkg/util/pattern/pattern_test.go
@@ -18,9 +18,9 @@ package pattern
 
 import (
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/util"
 	k8sMeta "github.com/loggie-io/loggie/pkg/util/pattern/k8smeta"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
+	"github.com/loggie-io/loggie/pkg/util/time"
 	corev1 "k8s.io/api/core/v1"
 	"os"
 	"reflect"
@@ -139,7 +139,7 @@ func TestEnvPattern(t *testing.T) {
 			args: args{
 				pattern: "pre-${+YYYY.MM.dd}",
 			},
-			want:    "pre-" + util.TimeFormatNow("YYYY.MM.dd"),
+			want:    "pre-" + time.TimeFormatNow("YYYY.MM.dd"),
 			wantErr: false,
 		},
 	}

--- a/pkg/util/time/format.go
+++ b/pkg/util/time/format.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package time
+
+import (
+	"github.com/pkg/errors"
+	"time"
+)
+
+const (
+	LayoutUnix   = "unix"
+	LayoutUnixMs = "unix_ms"
+)
+
+func Format(timestamp time.Time, location string, layout string) (interface{}, error) {
+	toLocation, err := time.LoadLocation(location)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "load location %s error", location)
+	}
+	timestamp = timestamp.In(toLocation)
+
+	switch layout {
+	case LayoutUnix:
+		return timestamp.Unix(), nil
+
+	case LayoutUnixMs:
+		return timestamp.UnixMilli(), nil
+
+	default:
+		return timestamp.Format(layout), nil
+	}
+}

--- a/pkg/util/time/time.go
+++ b/pkg/util/time/time.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package time
 
 import (
 	"strings"

--- a/pkg/util/time/time_test.go
+++ b/pkg/util/time/time_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package time
 
 import (
 	"github.com/loggie-io/loggie/pkg/util/yaml"


### PR DESCRIPTION
#### Proposed Changes:

* add schema interceptor

Usage:
```
---
## add timestamp fields
## rename body to message
interceptors:
  - type: schema
    addMeta:
      timestamp:
        key: "@timestamp"
    remap:
      body:
        key: message

---
## with location: "" or UTC, Local ...
## with golang style layout: 2006-01-02T15:04:05Z07:00(RFC3339) ...
interceptors:
  - type: schema
    addMeta:
      timestamp:
        key: "_timestamp_"
        location: Local
        layout: 2006-01-02T15:04:05Z07:00
    remap:
      body:
        key: _log_
```