### PR TITLE
Fix: regex set args `to` other than `key` in transformer interceptor

### DIFF
--- a/pkg/interceptor/transformer/action/regex.go
+++ b/pkg/interceptor/transformer/action/regex.go
@@ -104,7 +104,7 @@ func (r *Regex) act(e api.Event) error {
 
 	} else {
 		matchedMap := util.MatchGroupWithRegex(r.reg, val)
-		eventops.Set(e, r.key, matchedMap)
+		eventops.Set(e, r.to, matchedMap)
 	}
 
 	if r.key != r.to {

--- a/pkg/interceptor/transformer/example/pipeline.yml
+++ b/pkg/interceptor/transformer/example/pipeline.yml
@@ -1,5 +1,5 @@
 ---
-## test data: "10.244.0.1 - - [13/Dec/2021:12:40:48 +0000] "GET / HTTP/1.1" 404 683"
+## test data: `10.244.0.1 - - [13/Dec/2021:12:40:48 +0000] "GET / HTTP/1.1" 404 683`
 interceptors:
   - type: transformer
     actions:


### PR DESCRIPTION
#### Proposed Changes:

* regex set args `to` other than `key` in transformer interceptor
