### PR TITLE
Feat: add fmtKey() in transformer interceptor

### DIFF
--- a/loggie.yml
+++ b/loggie.yml
@@ -21,7 +21,7 @@ loggie:
     kubernetes:
       containerRuntime: containerd
       kubeconfig: ~/.kube/config
-      k8sFields:
+      typePodFields:
         namespace: "${_k8s.pod.namespace}"
         podname: "${_k8s.pod.name}"
         containername: "${_k8s.pod.container.name}"
@@ -32,9 +32,9 @@ loggie:
     sink:
       type: dev
       printEvents: true
-#      codec:
-#        type: json
-#        pretty: true
+      codec:
+        type: json
+        pretty: true
     sources:
       - type: file
         watcher:

--- a/pkg/discovery/kubernetes/controller/selectpodhandler.go
+++ b/pkg/discovery/kubernetes/controller/selectpodhandler.go
@@ -411,6 +411,7 @@ func (c *Controller) injectTypePodFields(dynamicContainerLogs bool, src *source.
 
 	k8sFields := make(map[string]interface{})
 
+	// Deprecated
 	m := c.config.Fields
 	if m.Namespace != "" {
 		k8sFields[m.Namespace] = pod.Namespace

--- a/pkg/interceptor/transformer/action/fmtkey.go
+++ b/pkg/interceptor/transformer/action/fmtkey.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/cfg"
+	"github.com/loggie-io/loggie/pkg/util"
+	"github.com/loggie-io/loggie/pkg/util/runtime"
+	"github.com/pkg/errors"
+	"regexp"
+)
+
+const (
+	FmtKeyName     = "fmtKey"
+	FmtKeyUsageMsg = "usage: fmtKey()"
+)
+
+func init() {
+	RegisterAction(FmtKeyName, func(args []string, extra cfg.CommonCfg) (Action, error) {
+		return NewFmtKey(args, extra)
+	})
+}
+
+type FmtKey struct {
+	reg   *regexp.Regexp
+	extra *FmtKeyExtra
+}
+
+type FmtKeyExtra struct {
+	Regex   string `yaml:"regex,omitempty" validate:"required"`
+	Replace string `yaml:"replace,omitempty" validate:"required"`
+}
+
+func NewFmtKey(args []string, extra cfg.CommonCfg) (*FmtKey, error) {
+	aCount := len(args)
+	if aCount != 0 {
+		return nil, errors.Errorf("invalid args, %s", FmtKeyUsageMsg)
+	}
+
+	extraCfg := &FmtKeyExtra{}
+	if err := cfg.UnpackFromCommonCfg(extra, extraCfg).Do(); err != nil {
+		return nil, err
+	}
+	pattern, err := extraCfg.compile()
+	if err != nil {
+		return nil, err
+	}
+
+	return &FmtKey{
+		reg:   pattern,
+		extra: extraCfg,
+	}, nil
+}
+
+func (re *FmtKeyExtra) compile() (*regexp.Regexp, error) {
+	if re.Regex == "" {
+		return nil, errors.New("fmtKey pattern is required")
+	}
+
+	p, err := util.CompilePatternWithJavaStyle(re.Regex)
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (r *FmtKey) act(e api.Event) error {
+	header := e.Header()
+	if header == nil {
+		return nil
+	}
+
+	obj := runtime.NewObject(header)
+	return obj.ConvertKeys(func(key string) string {
+		return r.matchAndReplace(key)
+	})
+}
+
+func (r *FmtKey) matchAndReplace(key string) string {
+	matched := r.reg.FindStringSubmatch(key)
+	if len(matched) > 0 {
+		return r.reg.ReplaceAllString(key, r.extra.Replace)
+	}
+	return ""
+}

--- a/pkg/util/runtime/object.go
+++ b/pkg/util/runtime/object.go
@@ -207,3 +207,36 @@ func flatten(token string, prefix string, src map[string]interface{}, dest map[s
 		}
 	}
 }
+
+type convertKeyFunc func(key string) string
+
+// ConvertKeys All keys in the object are processed by the convertKeyFunc function.
+// If convertKeyFunc returns empty, the key will not be processed.
+func (obj *Object) ConvertKeys(keyFunc convertKeyFunc) error {
+	m, err := obj.Map()
+	if err != nil {
+		return err
+	}
+	if len(m) == 0 {
+		return nil
+	}
+
+	convertKeys(m, keyFunc)
+	return nil
+}
+
+func convertKeys(src map[string]interface{}, keyFunc convertKeyFunc) {
+	for k, v := range src {
+		switch child := v.(type) {
+		case map[string]interface{}:
+			convertKeys(child, keyFunc)
+
+		default:
+			out := keyFunc(k)
+			if out != "" {
+				src[out] = v
+				delete(src, k)
+			}
+		}
+	}
+}


### PR DESCRIPTION
#### Proposed Changes:

* add fmtKey() action in transformer interceptor

#### Additional documentation:

Usage: 
```
interceptors:
  - type: transformer
    actions:
      - action: fmtKey()
         regex: foo.bar/(.*)
         replace: pre-${1}
```

- regex: match header keys
- replace: reformat the key to `replace`
