### PR TITLE
Feat: add opType in elasticsearch sink

### DIFF
--- a/pkg/sink/elasticsearch/client.go
+++ b/pkg/sink/elasticsearch/client.go
@@ -99,8 +99,11 @@ func (c *ClientSet) BulkIndex(ctx context.Context, batch api.Batch) error {
 		}
 
 		bulkIndexRequest := es.NewBulkIndexRequest().Index(idx).Doc(json.RawMessage(data))
-		if len(c.config.Etype) > 0 {
+		if c.config.Etype != "" {
 			bulkIndexRequest.Type(c.config.Etype)
+		}
+		if c.config.OpType != "" {
+			bulkIndexRequest.OpType(c.config.OpType)
 		}
 		if c.config.DocumentId != "" {
 			id, err := c.documentIdPattern.WithObject(headerObj).Render()

--- a/pkg/sink/elasticsearch/config.go
+++ b/pkg/sink/elasticsearch/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Schema     string   `yaml:"schema,omitempty"`
 	Sniff      *bool    `yaml:"sniff,omitempty"`
 	Gzip       *bool    `yaml:"gzip,omitempty"`
+	OpType     string   `yaml:"opType,omitempty"`
 }
 
 func (c *Config) Validate() error {


### PR DESCRIPTION
#### Proposed Changes:

* add opType param in elasticsearch sink, we should add `opType: create` when setting up a datastream in elasticsearch


#### Additional documentation:

```
sink:
  type: elasticsearch
  hosts: ["elasticsearch1:9200", "elasticsearch2:9200", "elasticsearch3:9200"]
  index: "log-${fields.service}-${+YYYY.MM.DD}"
  opType: create
```