### PR TITLE
Fix: interceptor order in pipelines

### DIFF
--- a/pkg/core/interceptor/extension.go
+++ b/pkg/core/interceptor/extension.go
@@ -20,7 +20,7 @@ import (
 	"github.com/loggie-io/loggie/pkg/core/api"
 )
 
-const DefaultOrder = 999
+const DefaultOrder = 900
 
 type Extension interface {
 	Order() int

--- a/pkg/interceptor/logalert/alerting.go
+++ b/pkg/interceptor/logalert/alerting.go
@@ -155,3 +155,15 @@ func (i *Interceptor) match(event api.Event) (matched bool, reason string, messa
 
 	return false, "", ""
 }
+
+func (i *Interceptor) Order() int {
+	return i.config.Order
+}
+
+func (i *Interceptor) BelongTo() (componentTypes []string) {
+	return i.config.BelongTo
+}
+
+func (i *Interceptor) IgnoreRetry() bool {
+	return true
+}

--- a/pkg/interceptor/logalert/config.go
+++ b/pkg/interceptor/logalert/config.go
@@ -17,10 +17,13 @@ limitations under the License.
 package logalert
 
 import (
+	"github.com/loggie-io/loggie/pkg/core/interceptor"
 	"regexp"
 )
 
 type Config struct {
+	interceptor.ExtensionConfig `yaml:",inline"`
+
 	Matcher Matcher `yaml:"matcher,omitempty"`
 	Labels  Labels  `yaml:"labels,omitempty"`
 }

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -473,7 +473,7 @@ func (p *Pipeline) startSink(sinkConfigs *sink.Config) error {
 
 func (p *Pipeline) startSinkConsumer(sinkConfig *sink.Config) {
 	interceptors := make([]sink.Interceptor, 0)
-	for _, inter := range p.r.LoadCodeInterceptors() {
+	for _, inter := range p.r.LoadInterceptors() {
 		i, ok := inter.(sink.Interceptor)
 		if !ok {
 			continue
@@ -625,7 +625,7 @@ func (p *Pipeline) startSourceProduct(sourceConfigs []*source.Config) {
 
 		sourceConfig := sc
 		interceptors := make([]source.Interceptor, 0)
-		for _, inter := range p.r.LoadCodeInterceptors() {
+		for _, inter := range p.r.LoadInterceptors() {
 			i, ok := inter.(source.Interceptor)
 			if !ok {
 				continue
@@ -660,7 +660,6 @@ func (p *Pipeline) startSourceProduct(sourceConfigs []*source.Config) {
 		}
 		go si.Source.ProductLoop(productFunc)
 	}
-	// go p.sourceInvokeLoop(si)
 }
 
 func (p *Pipeline) fillEventMetaAndHeader(e api.Event, config source.Config) {


### PR DESCRIPTION

#### Proposed Changes:

* when interceptor order is not configured, the interceptor maintains the order in the pipelines configuration.