### PR TITLE
Feat: add fieldsFromPath in source

### DIFF
--- a/pkg/core/source/config.go
+++ b/pkg/core/source/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	FieldsUnderKey  string                 `yaml:"fieldsUnderKey,omitempty" default:"fields"`
 	Fields          map[string]interface{} `yaml:"fields,omitempty"`
 	FieldsFromEnv   map[string]string      `yaml:"fieldsFromEnv,omitempty"`
+	FieldsFromPath  map[string]string      `yaml:"fieldsFromPath,omitempty"`
 	Codec           *codec.Config          `yaml:"codec,omitempty"`
 }
 
@@ -61,6 +62,15 @@ func (c *Config) DeepCopy() *Config {
 		newFieldsFromEnv = fe
 	}
 
+	var newFieldsFromPath map[string]string
+	if c.FieldsFromPath != nil {
+		fp := make(map[string]string)
+		for k, v := range c.FieldsFromPath {
+			fp[k] = v
+		}
+		newFieldsFromPath = fp
+	}
+
 	out := &Config{
 		Enabled:         c.Enabled,
 		Name:            c.Name,
@@ -70,6 +80,7 @@ func (c *Config) DeepCopy() *Config {
 		FieldsUnderKey:  c.FieldsUnderKey,
 		Fields:          newFields,
 		FieldsFromEnv:   newFieldsFromEnv,
+		FieldsFromPath:  newFieldsFromPath,
 		Codec:           c.Codec.DeepCopy(),
 	}
 
@@ -124,6 +135,17 @@ func (c *Config) Merge(from *Config) {
 			_, ok := c.FieldsFromEnv[k]
 			if !ok {
 				c.FieldsFromEnv[k] = v
+			}
+		}
+	}
+
+	if c.FieldsFromPath == nil {
+		c.FieldsFromPath = from.FieldsFromPath
+	} else {
+		for k, v := range from.FieldsFromPath {
+			_, ok := c.FieldsFromPath[k]
+			if !ok {
+				c.FieldsFromPath[k] = v
 			}
 		}
 	}

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -18,6 +18,7 @@ package pipeline
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -42,6 +43,8 @@ import (
 const (
 	FieldsUnderRoot = event.PrivateKeyPrefix + "FieldsUnderRoot"
 	FieldsUnderKey  = event.PrivateKeyPrefix + "FieldsUnderKey"
+
+	fieldsFromPathMaxBytes = 1024
 )
 
 var (
@@ -64,7 +67,8 @@ type Pipeline struct {
 	retryOutFuncs []api.OutFunc
 	index         uint32
 	epoch         *Epoch
-	envMap        map[string]string
+	envMap        map[string]interface{}
+	pathMap       map[string]interface{}
 
 	Running bool
 }
@@ -269,11 +273,8 @@ func (p *Pipeline) init(pipelineConfig Config) {
 	p.info.Stop = false
 	p.ns = make(map[string]api.Source)
 	p.nq = make(map[string]api.Queue)
-	p.envMap = make(map[string]string)
-	for _, e := range os.Environ() {
-		env := strings.SplitN(e, "=", 2)
-		p.envMap[env[0]] = env[1]
-	}
+	p.envMap = make(map[string]interface{})
+	p.pathMap = make(map[string]interface{})
 
 	// init event pool
 	p.info.EventPool = event.NewDefaultPool(pipelineConfig.Queue.BatchSize * (p.info.SinkCount + 1))
@@ -645,6 +646,9 @@ func (p *Pipeline) startSourceProduct(sourceConfigs []*source.Config) {
 		}
 		p.ns[sourceConfig.Name] = si.Source
 
+		p.initFieldsFromEnv(sc.FieldsFromEnv)
+		p.initFieldsFromPath(sc.FieldsFromPath)
+
 		sourceInvokerChain := buildSourceInvokerChain(sourceConfig.Name, &source.PublishInvoker{}, si.Interceptors)
 		productFunc := func(e api.Event) api.Result {
 			p.fillEventMetaAndHeader(e, *sourceConfig)
@@ -666,6 +670,47 @@ func (p *Pipeline) startSourceProduct(sourceConfigs []*source.Config) {
 	}
 }
 
+func (p *Pipeline) initFieldsFromEnv(fieldsFromEnv map[string]string) {
+	if len(fieldsFromEnv) == 0 {
+		return
+	}
+
+	for k, envKey := range fieldsFromEnv {
+		val := os.Getenv(envKey)
+		if val == "" {
+			log.Error("init fieldsFromEnv %s failed, env %s value is null", k, envKey)
+			continue
+		}
+		p.envMap[k] = val
+	}
+}
+
+func (p *Pipeline) initFieldsFromPath(fieldsFromPath map[string]string) {
+	if len(fieldsFromPath) == 0 {
+		return
+	}
+
+	for k, pathKey := range fieldsFromPath {
+		out, err := ioutil.ReadFile(pathKey)
+		if err != nil {
+			log.Error("init fieldsFromPath %s failed, read file %s err: %v", k, pathKey, err)
+			continue
+		}
+
+		size := len(out)
+		if size > fieldsFromPathMaxBytes {
+			log.Error("init fieldsFromPath %s failed, file size is: %d, which exceeds the maximum limit of %d", k, size, fieldsFromPathMaxBytes)
+			continue
+		}
+
+		str := string(out)
+		replacer := strings.NewReplacer("\n", "", "\r", "")
+		str = replacer.Replace(str)
+
+		p.pathMap[k] = str
+	}
+}
+
 func (p *Pipeline) fillEventMetaAndHeader(e api.Event, config source.Config) {
 	// add meta fields
 	e.Meta().Set(event.SystemProductTimeKey, time.Now())
@@ -683,28 +728,10 @@ func (p *Pipeline) fillEventMetaAndHeader(e api.Event, config source.Config) {
 	AddSourceFields(header, config.Fields, config.FieldsUnderRoot, config.FieldsUnderKey)
 
 	// add header source fields from env
-	if len(config.FieldsFromEnv) > 0 {
-		for k, envKey := range config.FieldsFromEnv {
-			envVal, ok := p.envMap[envKey]
-			if !ok || len(envVal) == 0 {
-				continue
-			}
-			if config.FieldsUnderRoot {
-				header[k] = envVal
-				continue
-			}
-			fieldsInHeader, exist := header[config.FieldsUnderKey]
-			if !exist {
-				f := make(map[string]interface{})
-				f[k] = envVal
-				header[config.FieldsUnderKey] = f
-				continue
-			}
-			if fieldsMap, ok := fieldsInHeader.(map[string]interface{}); ok {
-				fieldsMap[k] = envVal
-			}
-		}
-	}
+	AddSourceFields(header, p.envMap, config.FieldsUnderRoot, config.FieldsUnderKey)
+
+	// add header source fields from file
+	AddSourceFields(header, p.pathMap, config.FieldsUnderRoot, config.FieldsUnderKey)
 }
 
 func AddSourceFields(header map[string]interface{}, fields map[string]interface{}, underRoot bool, fieldsKey string) {


### PR DESCRIPTION
#### Proposed Changes:

* add fieldsFromPath in source

#### Additional documentation:

assume:
```
cat /tmp/foo
---
bar
```

when we add `fieldsFromPath` below:
```yaml
  - name: local
    sources:
      - type: file
        fieldsFromPath:
          test: /tmp/foo
```
then, events would add the fields:
```json
{
  "body": "xxxx",
  "fields": {
    "test": "bar"
  }
}
```
