### PR TITLE
Feat: add info listener for scape loggie version

### DIFF
--- a/pkg/eventbus/base.go
+++ b/pkg/eventbus/base.go
@@ -44,6 +44,7 @@ var (
 	ComponentBaseTopic    = "component"
 	SystemTopic           = "sys"
 	NormalizeTopic        = "normalize"
+	InfoTopic             = "info"
 )
 
 type BaseMetric struct {

--- a/pkg/include/include.go
+++ b/pkg/include/include.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/loggie-io/loggie/pkg/eventbus/export/prometheus"
 	_ "github.com/loggie-io/loggie/pkg/eventbus/listener/filesource"
 	_ "github.com/loggie-io/loggie/pkg/eventbus/listener/filewatcher"
+	_ "github.com/loggie-io/loggie/pkg/eventbus/listener/info"
 	_ "github.com/loggie-io/loggie/pkg/eventbus/listener/logalerting"
 	_ "github.com/loggie-io/loggie/pkg/eventbus/listener/normalize"
 	_ "github.com/loggie-io/loggie/pkg/eventbus/listener/pipeline"


### PR DESCRIPTION
#### Proposed Changes:

* add info listener for scape loggie version

#### Additional documentation:

```yaml
    listeners:
      info: ~
```

metrics:
```
# HELP loggie_info_stat Loggie info
# TYPE loggie_info_stat gauge
loggie_info_status{version="v1.3.0"} 1
```