### PR TITLE
FIX: copy action: body

### DIFF
--- a/pkg/util/eventops/event.go
+++ b/pkg/util/eventops/event.go
@@ -97,7 +97,7 @@ func Copy(e api.Event, from string, to string) {
 	obj := runtime.NewObject(e.Header())
 
 	if from == event.Body && len(e.Body()) != 0 {
-		obj.SetPath(to, e.Body())
+		obj.SetPath(to, string(e.Body()))
 		return
 	}
 


### PR DESCRIPTION
fix copy action,   - action: copy(body, res)

issues : #419 

test code

```
func TestCopyBody(t *testing.T) {

	assertions := assert.New(t)

	type fields struct {
		from string
		to   string
	}
	type args struct {
		e api.Event
	}
	tests := []struct {
		name   string
		fields fields
		args   args
	}{
		{
			name: "Copy body",
			fields: fields{
				from: "body",
				to:   "res",
			},
			args: args{
				e: event.NewEvent(map[string]interface{}{
					"aa": "hello",
				}, []byte("this is body")),
			},
		},
	}
	for _, tt := range tests {
		t.Run(tt.name, func(t1 *testing.T) {
			t := &Copy{
				from: tt.fields.from,
				to:   tt.fields.to,
			}
			err := t.act(tt.args.e)
			println(tt.args.e.String())
			assertions.NoError(err)
		})
	}

}
```

fix before:

```
=== RUN   TestCopyBody
=== RUN   TestCopyBody/Copy_body
header:{"aa":"hello","res":"dGhpcyBpcyBib2R5"}, body:"this is body"
--- PASS: TestCopyBody (0.00s)
    --- PASS: TestCopyBody/Copy_body (0.00s)
PASS
```

now:

```
=== RUN   TestCopyBody
=== RUN   TestCopyBody/Copy_body
header:{"res":"this is body","aa":"hello"}, body:"this is body"
--- PASS: TestCopyBody (0.00s)
    --- PASS: TestCopyBody/Copy_body (0.00s)
PASS
```


