### PR TITLE
feat:

### DIFF
--- a/cmd/loggie/main.go
+++ b/cmd/loggie/main.go
@@ -19,6 +19,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/automaxprocs/maxprocs"
+
 	"github.com/loggie-io/loggie/cmd/subcmd"
 	"github.com/loggie-io/loggie/pkg/control"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
@@ -32,13 +41,6 @@ import (
 	_ "github.com/loggie-io/loggie/pkg/include"
 	"github.com/loggie-io/loggie/pkg/ops/helper"
 	"github.com/loggie-io/loggie/pkg/util/yaml"
-	"github.com/pkg/errors"
-	"go.uber.org/automaxprocs/maxprocs"
-	"net/http"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 )
 
 var (
@@ -88,6 +90,7 @@ func main() {
 	eventbus.StartAndRun(syscfg.Loggie.MonitorEventBus)
 	// init log after error func
 	log.AfterError = eventbus.AfterErrorFunc
+	log.AfterErrorConfig = syscfg.Loggie.ErrorConfig
 
 	log.Info("pipelines config path: %s", pipelineConfigPath)
 	// pipeline config file

--- a/pkg/core/event/alert.go
+++ b/pkg/core/event/alert.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package event
+
+import (
+	"strings"
+	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/log"
+)
+
+const (
+	sourceName   = "sourceName"
+	pipelineName = "pipelineName"
+	timestamp    = "timestamp"
+
+	meta = "_meta"
+
+	DefaultAlertKey = "_defaultAlertKey"
+	NoDataKey       = "NoDataAlert"
+	Addition        = "_additions"
+	Fields          = "fields"
+	ReasonKey       = "reason"
+
+	AlertOriginDataKey = "Alerts"
+
+	loggieError = "LoggieError"
+)
+
+type Alert map[string]interface{}
+
+type AlertMap map[string][]Alert
+
+type PackageAndSendAlerts func(alerts []Alert)
+
+func NewAlert(e api.Event, lineLimit int) Alert {
+	systemData := map[string]interface{}{}
+
+	allMeta := e.Meta().GetAll()
+
+	if value, ok := allMeta[SystemSourceKey]; ok {
+		systemData[sourceName] = value
+	}
+
+	if value, ok := allMeta[SystemPipelineKey]; ok {
+		systemData[pipelineName] = value
+	}
+
+	if value, ok := allMeta[SystemProductTimeKey]; ok {
+		t, valueToTime := value.(time.Time)
+		if !valueToTime {
+			systemData[timestamp] = value
+		} else {
+			textTime, err := t.MarshalText()
+			if err == nil {
+				systemData[timestamp] = string(textTime)
+			} else {
+				systemData[timestamp] = value
+			}
+		}
+	}
+
+	alert := Alert{
+		meta: systemData,
+	}
+
+	if len(e.Body()) > 0 {
+		s := string(e.Body())
+		alert[Body] = splitBody(s, lineLimit)
+	}
+
+	for k, v := range e.Header() {
+		if k != Body {
+			alert[k] = v
+			continue
+		}
+
+		if value, ok := v.(string); ok {
+			alert[Body] = splitBody(value, lineLimit)
+		}
+	}
+
+	return alert
+}
+
+func splitBody(s string, lineLimit int) []string {
+	split := make([]string, 0)
+	for i, s := range strings.Split(s, "\n") {
+		if i > lineLimit {
+			log.Info("body exceeds line limit %d", lineLimit)
+			break
+		}
+		split = append(split, strings.TrimSpace(s))
+	}
+	return split
+}
+
+func ErrorToEvent(message string) *api.Event {
+	header := make(map[string]interface{})
+	var e api.Event
+	var meta api.Meta
+	meta = NewDefaultMeta()
+
+	meta.Set(SystemProductTimeKey, time.Now())
+	e = NewEvent(header, []byte(message))
+	e.Header()[ReasonKey] = loggieError
+	if len(log.AfterErrorConfig.Additions) > 0 {
+		e.Header()[Addition] = log.AfterErrorConfig.Additions
+	}
+
+	if len(log.AfterErrorConfig.Fields) > 0 {
+		e.Header()[Fields] = log.AfterErrorConfig.Fields
+	}
+	e.Fill(meta, header, e.Body())
+	return &e
+}
+
+func ErrorIntoEvent(event api.Event, message string) api.Event {
+	header := make(map[string]interface{})
+	var meta api.Meta
+	meta = NewDefaultMeta()
+	meta.Set(SystemProductTimeKey, time.Now())
+	header[ReasonKey] = loggieError
+	if len(log.AfterErrorConfig.Additions) > 0 {
+		header[Addition] = log.AfterErrorConfig.Additions
+	}
+
+	if len(log.AfterErrorConfig.Fields) > 0 {
+		header[Fields] = log.AfterErrorConfig.Fields
+	}
+	event.Fill(meta, header, []byte(message))
+	return event
+}
+
+func GenAlertsOriginData(alerts []Alert) map[string]interface{} {
+	return map[string]interface{}{
+		AlertOriginDataKey: alerts,
+	}
+}

--- a/pkg/core/log/global.go
+++ b/pkg/core/log/global.go
@@ -30,9 +30,10 @@ import (
 )
 
 var (
-	defaultLogger *Logger
-	AfterError    spi.AfterError
-	gLoggerConfig = &LoggerConfig{}
+	defaultLogger    *Logger
+	AfterError       spi.AfterError
+	AfterErrorConfig AfterErrorConfiguration
+	gLoggerConfig    = &LoggerConfig{}
 )
 
 func init() {
@@ -228,4 +229,9 @@ func afterErrorOpt(format string, a ...interface{}) {
 
 func Level() zerolog.Level {
 	return defaultLogger.l.GetLevel()
+}
+
+type AfterErrorConfiguration struct {
+	Additions map[string]interface{} `yaml:"additions,omitempty"`
+	Fields    map[string]interface{} `yaml:"fields,omitempty"`
 }

--- a/pkg/core/logalert/alertsender.go
+++ b/pkg/core/logalert/alertsender.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logalert
+
+import (
+	"github.com/loggie-io/loggie/pkg/core/event"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/loggie-io/loggie/pkg/util/pattern"
+	"github.com/loggie-io/loggie/pkg/util/runtime"
+)
+
+const (
+	DefaultAlertKey = event.DefaultAlertKey
+)
+
+type GroupConfig struct {
+	Pattern               *pattern.Pattern
+	AlertSendingThreshold int
+}
+
+func GroupAlerts(alertMap event.AlertMap, alerts []event.Alert, sendFunc event.PackageAndSendAlerts, p GroupConfig) {
+	checkAlertsLists := func(key string) {
+		list := alertMap[key]
+		if len(list) >= p.AlertSendingThreshold {
+			sendFunc(list)
+			alertMap[key] = nil
+		}
+	}
+
+	if p.Pattern == nil {
+		alertMap[DefaultAlertKey] = append(alertMap[DefaultAlertKey], alerts...)
+		checkAlertsLists(DefaultAlertKey)
+	} else {
+		keyMap := make(map[string]struct{})
+		for _, alert := range alerts {
+			obj := runtime.NewObject(alert)
+			render, err := p.Pattern.WithObject(obj).Render()
+			if err != nil {
+				log.Warn("fail to render group key. Put alert in default group")
+				alertMap[DefaultAlertKey] = append(alertMap[DefaultAlertKey], alert)
+				keyMap[DefaultAlertKey] = struct{}{}
+				continue
+			}
+
+			log.Debug("alert group key %s", render)
+			alertMap[render] = append(alertMap[render], alert)
+			keyMap[render] = struct{}{}
+		}
+
+		for key := range keyMap {
+			checkAlertsLists(key)
+		}
+	}
+
+}
+
+func GroupAlertsAtOnce(alerts []event.Alert, sendFunc event.PackageAndSendAlerts, p GroupConfig) {
+	if p.Pattern == nil {
+		sendFunc(alerts)
+	} else {
+		tempMap := make(event.AlertMap)
+		for _, alert := range alerts {
+			obj := runtime.NewObject(alert)
+			render, err := p.Pattern.WithObject(obj).Render()
+			if err != nil {
+				log.Warn("fail to render group key. Put alert in default group")
+				tempMap[DefaultAlertKey] = append(tempMap[DefaultAlertKey], alert)
+				continue
+			}
+
+			log.Debug("alert group key %s", render)
+			tempMap[render] = append(tempMap[render], alert)
+		}
+
+		for _, list := range tempMap {
+			sendFunc(list)
+		}
+	}
+
+}

--- a/pkg/core/logalert/config.go
+++ b/pkg/core/logalert/config.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logalert
+
+import "time"
+
+type Config struct {
+	Addr         []string      `yaml:"addr,omitempty"`
+	BufferSize   int           `yaml:"bufferSize,omitempty" default:"100"`
+	BatchTimeout time.Duration `yaml:"batchTimeout,omitempty" default:"10s"`
+	BatchSize    int           `yaml:"batchSize,omitempty" default:"10"`
+	AlertConfig  `yaml:",inline"`
+}
+
+type AlertConfig struct {
+	Template              string            `yaml:"template,omitempty"`
+	Timeout               time.Duration     `yaml:"timeout,omitempty" default:"30s"`
+	Headers               map[string]string `yaml:"headers,omitempty"`
+	Method                string            `yaml:"method,omitempty"`
+	LineLimit             int               `yaml:"lineLimit,omitempty" default:"10"`
+	GroupKey              string            `yaml:"groupKey,omitempty" default:"${_meta.pipelineName}-${_meta.sourceName}"`
+	AlertSendingThreshold int               `yaml:"alertSendingThreshold,omitempty" default:"1"`
+	SendLogAlertAtOnce    bool              `yaml:"sendLogAlertAtOnce"`
+	SendNoDataAlertAtOnce bool              `yaml:"sendNoDataAlertAtOnce" default:"true"`
+	SendLoggieError       bool              `yaml:"sendLoggieError"`
+	SendLoggieErrorAtOnce bool              `yaml:"sendLoggieErrorAtOnce"`
+}

--- a/pkg/core/sysconfig/config.go
+++ b/pkg/core/sysconfig/config.go
@@ -18,6 +18,7 @@ package sysconfig
 
 import (
 	"github.com/loggie-io/loggie/pkg/core/interceptor"
+	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/core/queue"
 	"github.com/loggie-io/loggie/pkg/core/reloader"
 	"github.com/loggie-io/loggie/pkg/core/sink"
@@ -36,11 +37,12 @@ type Config struct {
 }
 
 type Loggie struct {
-	Reload          reloader.ReloadConfig `yaml:"reload"`
-	Discovery       discovery.Config      `yaml:"discovery"`
-	Http            Http                  `yaml:"http" validate:"dive"`
-	MonitorEventBus eventbus.Config       `yaml:"monitor"`
-	Defaults        Defaults              `yaml:"defaults"`
+	Reload          reloader.ReloadConfig       `yaml:"reload"`
+	Discovery       discovery.Config            `yaml:"discovery"`
+	Http            Http                        `yaml:"http" validate:"dive"`
+	MonitorEventBus eventbus.Config             `yaml:"monitor"`
+	Defaults        Defaults                    `yaml:"defaults"`
+	ErrorConfig     log.AfterErrorConfiguration `yaml:"errorConfig"`
 }
 
 type Defaults struct {

--- a/pkg/eventbus/base.go
+++ b/pkg/eventbus/base.go
@@ -45,7 +45,7 @@ var (
 	ComponentBaseTopic    = "component"
 	SystemTopic           = "sys"
 	NormalizeTopic        = "normalize"
-	WebhookTopic          = "alertwebhook"
+	NoDataTopic           = "noDataAlert"
 	InfoTopic             = "info"
 )
 

--- a/pkg/include/include.go
+++ b/pkg/include/include.go
@@ -61,6 +61,7 @@ import (
 	_ "github.com/loggie-io/loggie/pkg/source/codec/regex"
 	_ "github.com/loggie-io/loggie/pkg/source/dev"
 	_ "github.com/loggie-io/loggie/pkg/source/elasticsearch"
+	_ "github.com/loggie-io/loggie/pkg/source/error"
 	_ "github.com/loggie-io/loggie/pkg/source/file"
 	_ "github.com/loggie-io/loggie/pkg/source/file/process"
 	_ "github.com/loggie-io/loggie/pkg/source/grpc"

--- a/pkg/interceptor/logalert/alerting.go
+++ b/pkg/interceptor/logalert/alerting.go
@@ -35,9 +35,9 @@ import (
 )
 
 const Type = "logAlert"
-const NoDataKey = "NoDataAlert"
-const addition = "_additions"
-const reasonKey = "reason"
+const NoDataKey = event.NoDataKey
+const addition = event.Addition
+const reasonKey = event.ReasonKey
 
 func init() {
 	pipeline.Register(api.INTERCEPTOR, Type, makeInterceptor)
@@ -146,8 +146,8 @@ func (i *Interceptor) Start() error {
 	if i.nodataMode {
 		i.runTicker()
 	}
-	if i.config.Template != nil {
-		eventbus.PublishOrDrop(eventbus.AlertTempTopic, *i.config.Template)
+	if len(i.config.Template) > 0 {
+		eventbus.PublishOrDrop(eventbus.AlertTempTopic, i.config.Template)
 	}
 
 	return nil
@@ -190,9 +190,7 @@ func (i *Interceptor) runTicker() {
 				}
 				e.Fill(meta, header, e.Body())
 
-				eventbus.PublishOrDrop(eventbus.LogAlertTopic, &e)
-
-				eventbus.PublishOrDrop(eventbus.WebhookTopic, &e)
+				eventbus.PublishOrDrop(eventbus.NoDataTopic, &e)
 
 			case <-i.eventFlag:
 				i.ticker.Reset(duration)

--- a/pkg/interceptor/logalert/config.go
+++ b/pkg/interceptor/logalert/config.go
@@ -37,13 +37,13 @@ const (
 type Config struct {
 	interceptor.ExtensionConfig `yaml:",inline"`
 
-	Matcher         Matcher           `yaml:"matcher,omitempty"`
-	Labels          Labels            `yaml:"labels,omitempty"`
-	Additions       map[string]string `yaml:"additions,omitempty"`
-	Ignore          []string          `yaml:"ignore,omitempty"`
-	Advanced        Advanced          `yaml:"advanced,omitempty"`
-	Template        *string           `yaml:"template,omitempty"`
-	SendOnlyMatched bool              `yaml:"sendOnlyMatched,omitempty"`
+	Matcher         Matcher                `yaml:"matcher,omitempty"`
+	Labels          Labels                 `yaml:"labels,omitempty"`
+	Additions       map[string]interface{} `yaml:"additions,omitempty"`
+	Ignore          []string               `yaml:"ignore,omitempty"`
+	Advanced        Advanced               `yaml:"advanced,omitempty"`
+	Template        string                 `yaml:"template,omitempty"`
+	SendOnlyMatched bool                   `yaml:"sendOnlyMatched,omitempty"`
 }
 
 type Matcher struct {

--- a/pkg/interceptor/logalert/example/example.yml
+++ b/pkg/interceptor/logalert/example/example.yml
@@ -15,6 +15,10 @@ loggie:
         batchTimeout: 10s
         batchSize: 1
         lineLimit: 10
+        groupKey: ${_meta.pipelineName}-${_meta.sourceName}
+        alertSendingThreshold: 10
+        sendLoggieError: true
+        sendLoggieErrorAtOnce: true
         template: |
           {
                   "alerts":
@@ -37,13 +41,14 @@ loggie:
                         ],
                         {{$first := true}}
                         {{range .Alerts}}
-                        {{if $first}}{{$first = false}}{{else}}
+                        {{if $first}}{{$first = false}}
                         "commonLabels": {
                           "namespace": "{{._additions.namespace}}",
                           "module": "{{._additions.module}}",
                           "alertname": "{{._additions.alertname}}",
                           "cluster": "{{._additions.cluster}}"
                         }
+                        {{else}}
                         {{end}}
                         {{end}}
           }

--- a/pkg/sink/alertwebhook/alert_test.go
+++ b/pkg/sink/alertwebhook/alert_test.go
@@ -15,7 +15,7 @@ func TestNewAlert(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		want  Alert
+		want  event.Alert
 		event api.Event
 	}{
 		{
@@ -34,7 +34,7 @@ func TestNewAlert(t *testing.T) {
 					event.SystemProductTimeKey: now,
 				}},
 			},
-			want: Alert{
+			want: event.Alert{
 				"body":   []string{"message"},
 				"reason": "reason",
 				"fields": map[string]interface{}{
@@ -50,7 +50,7 @@ func TestNewAlert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			alert := NewAlert(tt.event, 10)
+			alert := event.NewAlert(tt.event, 10)
 			assert.EqualValues(t, tt.want, alert, "should be same")
 		})
 	}

--- a/pkg/sink/alertwebhook/example/example.yml
+++ b/pkg/sink/alertwebhook/example/example.yml
@@ -24,6 +24,7 @@ pipelines:
           module: "loggie-alert"
           alertname: "zzy-alert-test"
           cluster: "local-cluster"
+          namespace: "default"
         advanced:
           enabled: true
           mode: [ "noData","regexp" ]
@@ -51,6 +52,10 @@ pipelines:
       addr: http://localhost:8080/loggie
       headers:
         api: test1
+      groupKey: ${_meta.pipelineName}-${_meta.sourceName}
+      alertSendingThreshold: 10
+      sendLoggieError: true
+      sendLoggieErrorAtOnce: true
       template: |
         {
         "alerts":
@@ -73,13 +78,14 @@ pipelines:
         ],
         {{$first := true}}
         {{range .Alerts}}
-        {{if $first}}{{$first = false}}{{else}}
+        {{if $first}}{{$first = false}}
         "commonLabels": {
         "namespace": "{{._additions.namespace}}",
         "module": "{{._additions.module}}",
         "alertname": "{{._additions.alertname}}",
         "cluster": "{{._additions.cluster}}"
         }
+        {{else}}
         {{end}}
         {{end}}
         }

--- a/pkg/source/error/config.go
+++ b/pkg/source/error/config.go
@@ -14,13 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package alertwebhook
-
-import (
-	"github.com/loggie-io/loggie/pkg/core/logalert"
-)
+package error
 
 type Config struct {
-	Addr                 string `yaml:"addr,omitempty"`
-	logalert.AlertConfig `yaml:",inline"`
+	Additions        map[string]interface{} `yaml:"additions,omitempty"`
+	Fields           map[string]interface{} `yaml:"fields,omitempty"`
+	ErrorTestEnabled bool                   `yaml:"errorTestEnabled"`
 }

--- a/pkg/source/error/example/pipelines.yml
+++ b/pkg/source/error/example/pipelines.yml
@@ -1,0 +1,9 @@
+# example for loggie error source
+pipelines:
+  - name: local
+    sources:
+      - type: error
+        name: error
+        errorTestEnabled: true
+    sink:
+      type: alertWebhook

--- a/pkg/source/error/source.go
+++ b/pkg/source/error/source.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2022 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package error
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/event"
+	"github.com/loggie-io/loggie/pkg/core/log"
+	"github.com/loggie-io/loggie/pkg/eventbus"
+	"github.com/loggie-io/loggie/pkg/pipeline"
+)
+
+const Type = "error"
+
+func init() {
+	pipeline.Register(api.SOURCE, Type, makeSource)
+}
+
+func makeSource(info pipeline.Info) api.Component {
+	return &LoggieError{
+		pipelineName: info.PipelineName,
+		config:       &Config{},
+		stop:         make(chan struct{}),
+		eventPool:    info.EventPool,
+	}
+}
+
+type LoggieError struct {
+	pipelineName string
+	name         string
+	config       *Config
+	stop         chan struct{}
+	eventChan    chan string
+	eventPool    *event.Pool
+	listener     *Listener
+	subscribe    *eventbus.Subscribe
+}
+
+func (d *LoggieError) Config() interface{} {
+	return d.config
+}
+
+func (d *LoggieError) Category() api.Category {
+	return api.SOURCE
+}
+
+func (d *LoggieError) Type() api.Type {
+	return Type
+}
+
+func (d *LoggieError) String() string {
+	return fmt.Sprintf("%s/%s", api.SOURCE, Type)
+}
+
+func (d *LoggieError) Init(context api.Context) error {
+	d.name = context.Name()
+	d.listener = &Listener{
+		name:   fmt.Sprintf("%s/%s", d.pipelineName, name),
+		source: d,
+		done:   make(chan struct{}),
+	}
+
+	d.stop = make(chan struct{})
+	d.eventChan = make(chan string)
+
+	d.subscribe = eventbus.RegistryTemporary(d.listener.name, func() eventbus.Listener {
+		return d.listener
+	}, eventbus.WithTopic(eventbus.ErrorTopic))
+	return nil
+}
+
+func (d *LoggieError) Start() error {
+	_ = d.listener.Start()
+	if d.config.ErrorTestEnabled {
+		go d.runTest()
+	}
+	return nil
+}
+
+func (d *LoggieError) Stop() {
+	eventbus.UnRegistrySubscribeTemporary(d.subscribe)
+	d.listener.Stop()
+	close(d.stop)
+}
+
+func (d *LoggieError) runTest() {
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.stop:
+			return
+		case <-ticker.C:
+			log.Error("test error %s", time.Now().String())
+		}
+	}
+}
+
+func (d *LoggieError) ProductLoop(productFunc api.ProductFunc) {
+
+	for {
+		select {
+		case <-d.stop:
+			return
+
+		case message := <-d.eventChan:
+			e := d.eventPool.Get()
+			event.ErrorIntoEvent(e, message)
+			header := e.Header()
+			if len(d.config.Additions) > 0 {
+				header[event.Addition] = d.config.Additions
+			}
+			if len(d.config.Fields) > 0 {
+				header[event.Fields] = d.config.Fields
+			}
+			e.Fill(e.Meta(), header, e.Body())
+			productFunc(e)
+		}
+	}
+}
+
+func (d *LoggieError) consumeEvent(message string) {
+	select {
+	case d.eventChan <- message:
+	default:
+	}
+}
+
+func (d *LoggieError) Commit(events []api.Event) {
+	d.eventPool.PutAll(events)
+}

--- a/pkg/util/httpCode.go
+++ b/pkg/util/httpCode.go
@@ -14,13 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package alertwebhook
+package util
 
-import (
-	"github.com/loggie-io/loggie/pkg/core/logalert"
-)
-
-type Config struct {
-	Addr                 string `yaml:"addr,omitempty"`
-	logalert.AlertConfig `yaml:",inline"`
+func Is2xxSuccess(code int) bool {
+	return code >= 200 && code <= 299
 }


### PR DESCRIPTION
loggie logalert adv

#### Proposed Changes:

* logAlerts can be grouped by groupkey.
* logAlert listener and alertWebhook can save alerts until numbers of alerts reach some value.
* Error logs of Loggie can be sent to logAlert listener or alertWebhook. 
* Error logs of Loggie can be configured as loggie source.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional documentation:

```docs

```