### PR TITLE
fix(source): panic when kubeEvent Series is nil

### DIFF
--- a/pkg/source/kubernetes_event/eventer.go
+++ b/pkg/source/kubernetes_event/eventer.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/core/global"
-	"go.uber.org/atomic"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/core/global"
+	"go.uber.org/atomic"
 
 	"github.com/loggie-io/loggie/pkg/core/api"
 	"github.com/loggie-io/loggie/pkg/core/event"
@@ -257,7 +258,7 @@ func (k *KubeEvent) filter(ev *corev1.Event) bool {
 			}
 		}
 
-		if ev.Series.LastObservedTime.Time != zeroTime {
+		if ev.Series != nil && ev.Series.LastObservedTime.Time != zeroTime {
 			if !ev.Series.LastObservedTime.After(k.startTime) {
 				return true
 			}


### PR DESCRIPTION
#### Proposed Changes:

* fix kubeEvent source panic when enabled watchLatestEvents

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #458 

#### Additional documentation:

```docs
None
```