### PR TITLE
Fix: parse condition failed when contain ERROR

### DIFF
--- a/pkg/interceptor/transformer/condition/conditions.go
+++ b/pkg/interceptor/transformer/condition/conditions.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	AndInStr = " AND "
+	OrInStr  = " OR "
 	AND      = "AND"
 	OR       = "OR"
 	NEGATIVE = "NOT"
@@ -113,21 +115,8 @@ func GetConditions(expression string) ([]*Instance, string, error) {
 
 func getSubExpressions(expression string) ([]*Instance, string, error) {
 	var expressions []*Instance
-	var connector string
 
-	var ex []string
-	if strings.Contains(expression, AND) {
-		sub := strings.Split(expression, AND)
-		connector = AND
-		ex = append(ex, sub...)
-	} else if strings.Contains(expression, OR) {
-		sub := strings.Split(expression, OR)
-		connector = OR
-		ex = append(ex, sub...)
-	} else {
-		ex = append(ex, expression)
-	}
-
+	connector, ex := extractFunctions(expression)
 	for _, e := range ex {
 		var negative bool
 		e = strings.TrimSpace(e)
@@ -150,4 +139,23 @@ func getSubExpressions(expression string) ([]*Instance, string, error) {
 	}
 
 	return expressions, connector, nil
+}
+
+// extractFunctions splits a string into functions and connectors.
+func extractFunctions(expression string) (conn string, fn []string) {
+	var connector string
+	var ex []string
+	if strings.Contains(expression, AndInStr) {
+		sub := strings.Split(expression, AndInStr)
+		connector = AND
+		ex = append(ex, sub...)
+	} else if strings.Contains(expression, OrInStr) {
+		sub := strings.Split(expression, OrInStr)
+		connector = OR
+		ex = append(ex, sub...)
+	} else {
+		ex = append(ex, expression)
+	}
+
+	return connector, ex
 }

--- a/pkg/interceptor/transformer/condition/conditions_test.go
+++ b/pkg/interceptor/transformer/condition/conditions_test.go
@@ -1,0 +1,51 @@
+package condition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExtractFunctions(t *testing.T) {
+	tests := []struct {
+		input             string
+		expectedConnector string
+		expectedFunctions []string
+	}{
+		{
+			input:             "func1(a, ERROR)",
+			expectedConnector: "",
+			expectedFunctions: []string{"func1(a, ERROR)"},
+		},
+		{
+			input:             "func1(a, ERROR) OR func2(a, foo) OR func3(b, bar)",
+			expectedConnector: "OR",
+			expectedFunctions: []string{"func1(a, ERROR)", "func2(a, foo)", "func3(b, bar)"},
+		},
+		{
+			input:             "funcA(a, foo) AND funcB(b, bar)",
+			expectedConnector: "AND",
+			expectedFunctions: []string{"funcA(a, foo)", "funcB(b, bar)"},
+		},
+		{
+			input:             "contain(a, foo) OR equal(b, bar)",
+			expectedConnector: "OR",
+			expectedFunctions: []string{"contain(a, foo)", "equal(b, bar)"},
+		},
+		{
+			input:             "NOT contain(a, foo) OR equal(b, bar)",
+			expectedConnector: "OR",
+			expectedFunctions: []string{"NOT contain(a, foo)", "equal(b, bar)"},
+		},
+		{
+			input:             "NOT contain(a, foo) AND NOT equal(b, bar)",
+			expectedConnector: "AND",
+			expectedFunctions: []string{"NOT contain(a, foo)", "NOT equal(b, bar)"},
+		},
+	}
+
+	for _, test := range tests {
+		connector, fn := extractFunctions(test.input)
+		assert.Equal(t, test.expectedConnector, connector, "input: %q", test.input)
+		assert.Equal(t, test.expectedFunctions, fn, "input: %q", test.input)
+	}
+}


### PR DESCRIPTION
#### Proposed Changes:

- Fix:  contain(level,ERROR) parse failed in transformer condition.

