### PR TITLE
fix: ratelimit may lose precision on Linux

### DIFF
--- a/pkg/interceptor/limit/clock.go
+++ b/pkg/interceptor/limit/clock.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package limit
 
-import "time"
+import (
+	"runtime"
+	"time"
+)
 
 type clockDescriptor struct {
 	clock Clock
@@ -30,7 +33,11 @@ func (c *clockDescriptor) Sleep(d time.Duration) {
 	// Sleeps less than 10ms use long polling instead to improve precision
 	if d < time.Millisecond*10 {
 		start := time.Now()
+		needYield := d >= time.Millisecond*5
 		for time.Since(start) < d {
+			if needYield {
+				runtime.Gosched()
+			}
 			// do nothing
 		}
 		return

--- a/pkg/interceptor/limit/clock.go
+++ b/pkg/interceptor/limit/clock.go
@@ -27,7 +27,7 @@ func NewHighPrecisionClockDescriptor(clock Clock) Clock {
 }
 
 func (c *clockDescriptor) Sleep(d time.Duration) {
-	// 小于10ms的睡眠使用长轮询来代替以提高精度
+	// Sleeps less than 10ms use long polling instead to improve precision
 	if d < time.Millisecond*10 {
 		start := time.Now()
 		for time.Since(start) < d {

--- a/pkg/interceptor/limit/interceptor.go
+++ b/pkg/interceptor/limit/interceptor.go
@@ -68,7 +68,12 @@ func (i *Interceptor) Init(context api.Context) error {
 
 func (i *Interceptor) Start() error {
 	log.Info("rate limit: qps->%d", i.qps)
-	i.l = newUnsafeBased(i.qps, WithoutLock())
+	ops := make([]Option, 0)
+	ops = append(ops, WithoutLock())
+	if i.config.HighPrecision {
+		ops = append(ops, WithHighPrecision())
+	}
+	i.l = newUnsafeBased(i.qps, ops...)
 	return nil
 }
 

--- a/pkg/interceptor/limit/limiter.go
+++ b/pkg/interceptor/limit/limiter.go
@@ -40,10 +40,11 @@ type Clock interface {
 
 // config configures a limiter.
 type config struct {
-	clock    Clock
-	maxSlack time.Duration
-	per      time.Duration
-	lock     bool
+	clock         Clock
+	maxSlack      time.Duration
+	per           time.Duration
+	lock          bool
+	highPrecision bool
 }
 
 // Option configures a Limiter.
@@ -74,6 +75,18 @@ func (uo unLockOption) apply(c *config) {
 
 func WithoutLock() Option {
 	return unLockOption{}
+}
+
+type highPrecisionOption struct {
+}
+
+func (hpo highPrecisionOption) apply(c *config) {
+	c.highPrecision = true
+	c.clock = NewHighPrecisionClockDescriptor(c.clock)
+}
+
+func WithHighPrecision() Option {
+	return highPrecisionOption{}
 }
 
 type slackOption int


### PR DESCRIPTION
#### Proposed Changes:

* ratelimit interceptor

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #509

#### Additional documentation:

```docs

highPrecision: true

> The high precision mode of the rate limiting component can be enabled, but it comes with the cost of increased CPU usage. Consider enabling it when the limited QPS exceeds 20,000

```