### PR TITLE
fix: large line may cause oom

### DIFF
--- a/pkg/source/file/config.go
+++ b/pkg/source/file/config.go
@@ -99,6 +99,7 @@ type CleanFiles struct {
 
 type ReaderConfig struct {
 	LineDelimiter          LineDelimiterValue `yaml:"lineDelimiter,omitempty"`
+	MaxSingleLineBytes     int64              `yaml:"maxSingleLineBytes,omitempty" default:"67108864" validate:"gt=65536"` // default 67108864 = 64MB
 	WorkerCount            int                `yaml:"workerCount,omitempty" default:"1"`
 	ReadChanSize           int                `yaml:"readChanSize,omitempty" default:"512"`     // deprecated
 	ReadBufferSize         int                `yaml:"readBufferSize,omitempty" default:"65536"` // The buffer size used for the file reading. default 65536 = 64k = 16*PAGE_SIZE

--- a/pkg/source/file/job.go
+++ b/pkg/source/file/job.go
@@ -181,6 +181,10 @@ func (j *Job) RenameTo(newFilename string) {
 	j.renameTime.Store(time.Now())
 }
 
+func (j *Job) FileName() string {
+	return j.filename
+}
+
 func (j *Job) IsRename() bool {
 	rt := j.renameTime.Load()
 	if rt == nil || rt == NilOfTime {

--- a/pkg/source/file/process/line.go
+++ b/pkg/source/file/process/line.go
@@ -67,7 +67,7 @@ func (lp *LineProcessor) Process(processorChain file.ProcessChain, ctx *file.Job
 		if int64(len(ctx.BacklogBuffer)) <= lp.maxSingleLineBytes {
 			ctx.BacklogBuffer = append(ctx.BacklogBuffer, readBuffer[processed:]...)
 		} else {
-			log.Warn("[%s]The length of the backlog buffer exceeds the limit(%s kb), the remaining content on the line will be ignored with offset(%d).", job.FileName(), lp.maxSingleLineBytes/1024, ctx.LastOffset-read)
+			log.Warn("[%s]The length of the backlog buffer exceeds the limit(%d kb), the remaining content on the line will be ignored with offset(%d).", job.FileName(), lp.maxSingleLineBytes/1024, ctx.LastOffset-read)
 		}
 	}
 }

--- a/pkg/source/file/process/line.go
+++ b/pkg/source/file/process/line.go
@@ -2,9 +2,9 @@ package process
 
 import (
 	"bytes"
-	"github.com/loggie-io/loggie/pkg/core/log"
 	"time"
 
+	"github.com/loggie-io/loggie/pkg/core/log"
 	"github.com/loggie-io/loggie/pkg/source/file"
 )
 

--- a/pkg/source/file/process/loop.go
+++ b/pkg/source/file/process/loop.go
@@ -1,8 +1,9 @@
 package process
 
 import (
-	"github.com/loggie-io/loggie/pkg/source/file"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/source/file"
 )
 
 func init() {


### PR DESCRIPTION
#### Proposed Changes:

* file source

#### Additional documentation:

```docs
maxSingleLineBytes: 67108864
```