### PR TITLE
Feat: add resultStatus in dev sink to simulate failure, drop

### DIFF
--- a/pkg/sink/dev/config.go
+++ b/pkg/sink/dev/config.go
@@ -26,4 +26,7 @@ type Config struct {
 
 	PrintMetrics    bool          `yaml:"printMetrics,omitempty"`
 	MetricsInterval time.Duration `yaml:"printMetricsInterval,omitempty" default:"1s"`
+
+	// resultStatus can be used to simulate failure, drop
+	ResultStatus string `yaml:"resultStatus,omitempty" default:"success"`
 }


### PR DESCRIPTION
- add `resultStatus` in dev sink.
- add `/api/v1/pipeline/{pipelineName}/sink/dev`?status=success/fail/drop API，which can set dev sink return status dynamically.