### PR TITLE
Feat: add ignoreUnknownTopicOrPartition in kafka sink

### DIFF
--- a/pkg/sink/franz/config.go
+++ b/pkg/sink/franz/config.go
@@ -24,18 +24,19 @@ import (
 const defaultKerberosConfigPath = "/etc/krb5.conf"
 
 type Config struct {
-	Brokers             []string          `yaml:"brokers,omitempty" validate:"required"`
-	Topic               string            `yaml:"topic,omitempty" validate:"required" default:"loggie"`
-	IfRenderTopicFailed RenderTopicFail   `yaml:"ifRenderTopicFailed,omitempty"`
-	Balance             string            `yaml:"balance,omitempty" default:"roundRobin"`
-	BatchSize           int               `yaml:"batchSize,omitempty"`
-	BatchBytes          int32             `yaml:"batchBytes,omitempty"`
-	RetryTimeout        time.Duration     `yaml:"retryTimeout,omitempty"`
-	WriteTimeout        time.Duration     `yaml:"writeTimeout,omitempty"`
-	Compression         string            `yaml:"compression,omitempty" default:"gzip"`
-	SASL                SASL              `yaml:"sasl,omitempty"`
-	TLS                 TLS               `yaml:"tls,omitempty"`
-	Security            map[string]string `yaml:"security,omitempty"`
+	Brokers                       []string          `yaml:"brokers,omitempty" validate:"required"`
+	Topic                         string            `yaml:"topic,omitempty" validate:"required" default:"loggie"`
+	IfRenderTopicFailed           RenderTopicFail   `yaml:"ifRenderTopicFailed,omitempty"`
+	IgnoreUnknownTopicOrPartition bool              `yaml:"ignoreUnknownTopicOrPartition,omitempty"`
+	Balance                       string            `yaml:"balance,omitempty" default:"roundRobin"`
+	BatchSize                     int               `yaml:"batchSize,omitempty"`
+	BatchBytes                    int32             `yaml:"batchBytes,omitempty"`
+	RetryTimeout                  time.Duration     `yaml:"retryTimeout,omitempty"`
+	WriteTimeout                  time.Duration     `yaml:"writeTimeout,omitempty"`
+	Compression                   string            `yaml:"compression,omitempty" default:"gzip"`
+	SASL                          SASL              `yaml:"sasl,omitempty"`
+	TLS                           TLS               `yaml:"tls,omitempty"`
+	Security                      map[string]string `yaml:"security,omitempty"`
 }
 
 type RenderTopicFail struct {

--- a/pkg/sink/franz/pipeline.yml
+++ b/pkg/sink/franz/pipeline.yml
@@ -1,0 +1,4 @@
+sink:
+  type: franzKafka
+  brokers: ["127.0.0.1:6400"]
+  topic: "log-${fields.topic}"

--- a/pkg/sink/franz/sink.go
+++ b/pkg/sink/franz/sink.go
@@ -28,6 +28,7 @@ import (
 	"github.com/loggie-io/loggie/pkg/util/pattern"
 	"github.com/loggie-io/loggie/pkg/util/runtime"
 	"github.com/pkg/errors"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -188,7 +189,12 @@ func (s *Sink) Consume(batch api.Batch) api.Result {
 
 	if s.writer != nil {
 		ret := s.writer.ProduceSync(ctx, records...)
-		if ret.FirstErr() != nil {
+		err := ret.FirstErr()
+		if err != nil {
+			if errors.Is(err, kerr.UnknownTopicOrPartition) && s.config.IgnoreUnknownTopicOrPartition {
+				return result.Success()
+			}
+
 			return result.Fail(errors.New(fmt.Sprintf("franz ProduceSync error:%s", ret.FirstErr())))
 		}
 		return result.Success()

--- a/pkg/sink/kafka/config.go
+++ b/pkg/sink/kafka/config.go
@@ -48,20 +48,21 @@ const (
 )
 
 type Config struct {
-	Brokers             []string        `yaml:"brokers,omitempty" validate:"required"`
-	Topic               string          `yaml:"topic,omitempty" validate:"required" default:"loggie"`
-	IfRenderTopicFailed RenderTopicFail `yaml:"ifRenderTopicFailed,omitempty"`
-	Balance             string          `yaml:"balance,omitempty" default:"roundRobin"`
-	Compression         string          `yaml:"compression,omitempty" default:"gzip"`
-	MaxAttempts         int             `yaml:"maxAttempts,omitempty"`
-	BatchSize           int             `yaml:"batchSize,omitempty"`
-	BatchBytes          int64           `yaml:"batchBytes,omitempty"`
-	BatchTimeout        time.Duration   `yaml:"batchTimeout,omitempty"`
-	ReadTimeout         time.Duration   `yaml:"readTimeout,omitempty"`
-	WriteTimeout        time.Duration   `yaml:"writeTimeout,omitempty"`
-	RequiredAcks        int             `yaml:"requiredAcks,omitempty"`
-	SASL                SASL            `yaml:"sasl,omitempty"`
-	PartitionKey        string          `yaml:"partitionKey,omitempty"`
+	Brokers                       []string        `yaml:"brokers,omitempty" validate:"required"`
+	Topic                         string          `yaml:"topic,omitempty" validate:"required" default:"loggie"`
+	IfRenderTopicFailed           RenderTopicFail `yaml:"ifRenderTopicFailed,omitempty"`
+	IgnoreUnknownTopicOrPartition bool            `yaml:"ignoreUnknownTopicOrPartition,omitempty"`
+	Balance                       string          `yaml:"balance,omitempty" default:"roundRobin"`
+	Compression                   string          `yaml:"compression,omitempty" default:"gzip"`
+	MaxAttempts                   int             `yaml:"maxAttempts,omitempty"`
+	BatchSize                     int             `yaml:"batchSize,omitempty"`
+	BatchBytes                    int64           `yaml:"batchBytes,omitempty"`
+	BatchTimeout                  time.Duration   `yaml:"batchTimeout,omitempty"`
+	ReadTimeout                   time.Duration   `yaml:"readTimeout,omitempty"`
+	WriteTimeout                  time.Duration   `yaml:"writeTimeout,omitempty"`
+	RequiredAcks                  int             `yaml:"requiredAcks,omitempty"`
+	SASL                          SASL            `yaml:"sasl,omitempty"`
+	PartitionKey                  string          `yaml:"partitionKey,omitempty"`
 }
 
 type RenderTopicFail struct {

--- a/pkg/sink/kafka/sink.go
+++ b/pkg/sink/kafka/sink.go
@@ -176,6 +176,10 @@ func (s *Sink) Consume(batch api.Batch) api.Result {
 	if s.writer != nil {
 		err := s.writer.WriteMessages(context.Background(), km...)
 		if err != nil {
+			if errors.Is(err, kafka.UnknownTopicOrPartition) && s.config.IgnoreUnknownTopicOrPartition {
+				return result.Success()
+			}
+
 			return result.Fail(errors.WithMessage(err, "write to kafka"))
 		}
 


### PR DESCRIPTION
```
sink:
  type: kafka
  brokers: ["127.0.0.1:6400"]
  topic: "log-${fields.topic}"
  ignoreUnknownTopicOrPartition: true
```
if ignoreUnknownTopicOrPartition: true, ignore error when kafka topic or partion not exsit.