### PR TITLE
fix(interceptor): Optimizes maxbytes interceptions

### DIFF
--- a/pkg/interceptor/maxbytes/interceptor.go
+++ b/pkg/interceptor/maxbytes/interceptor.go
@@ -92,8 +92,7 @@ func (i *Interceptor) IgnoreRetry() bool {
 	return true
 }
 
-// subUtf8 提供字节数组按字节长度截取，如果最后一个字节非utf8字节结尾则往后取
-// 示例：bytes=中文, maxBytes=2 => 中
+// subUtf8 Provides byte arrays that are truncated by byte length, or later if the last byte is not utf8 byte ending
 func subUtf8(bytes []byte, maxBytes int) []byte {
 	for i := maxBytes; i < len(bytes); i++ {
 		if utf8.RuneStart(bytes[i]) {


### PR DESCRIPTION
#### Proposed Changes:

* interceptor/maxbytes/interceptor.go


#### Which issue(s) this PR fixes:
当前：maxbytes配置的是字节长度，截取的时候当成字符长度，比如body=我爱祖国啊，maxbytes=4，截取后变成`我爱祖国`，截取后字节长度就变成12了
如果按照字节长度截取，则截取后变成`我�`，发送到es时则报错：`Invalid UTF-8 middle byte`

现在优化为：按照字节长度截取，如果最后一个字节非utf8字节结尾则往后取，即截取后为`我爱`