### PR TITLE
Fix: Convert to string type when returning [] byte type

### DIFF
--- a/pkg/interceptor/transformer/condition/equal.go
+++ b/pkg/interceptor/transformer/condition/equal.go
@@ -51,5 +51,10 @@ func NewEqual(args []string) (*Equal, error) {
 }
 
 func (eq *Equal) Check(e api.Event) bool {
-	return eq.value == eventops.Get(e, eq.field)
+	value := eventops.Get(e, eq.field)
+	if byteValue, ok := value.([]byte); ok {
+		value = string(byteValue)
+	}
+
+	return eq.value == value
 }


### PR DESCRIPTION
场景：
当 transformer interceptor 的 equal(key, target) 条件，key 设置为 body 时，eventops.Get 函数返回的 interface{} 的底层类型是 []byte，与 eq.value 的 string 类型不匹配，导致 == 判断失败。

处理方法：
当获取到 eventops.Get 返回值时进行类型断言判断是否是 []byte 类型，如果是则进行类型转换，再进行比较。
