### PR TITLE
[interceptor/transformer] feat:support setFloat/setInt/setBool

### DIFF
--- a/pkg/interceptor/transformer/action/set.go
+++ b/pkg/interceptor/transformer/action/set.go
@@ -42,16 +42,13 @@ func init() {
 		return NewSet(args)
 	})
 	RegisterAction(SetFloatName, func(args []string, extra cfg.CommonCfg) (Action, error) {
-		args = append(args, "float")
-		return NewStrConvSet(args, SetFloatMsg)
+		return NewStrConvSet(args, "float", SetFloatMsg)
 	})
 	RegisterAction(SetIntName, func(args []string, extra cfg.CommonCfg) (Action, error) {
-		args = append(args, "int")
-		return NewStrConvSet(args, SetIntMsg)
+		return NewStrConvSet(args, "int", SetIntMsg)
 	})
 	RegisterAction(SetBoolName, func(args []string, extra cfg.CommonCfg) (Action, error) {
-		args = append(args, "bool")
-		return NewStrConvSet(args, SetBoolMsg)
+		return NewStrConvSet(args, "bool", SetBoolMsg)
 	})
 }
 
@@ -83,15 +80,15 @@ type StrConvSet struct {
 	dstType string
 }
 
-func NewStrConvSet(args []string, msg string) (*StrConvSet, error) {
-	if len(args) != 3 {
+func NewStrConvSet(args []string, destType, msg string) (*StrConvSet, error) {
+	if len(args) != 2 {
 		return nil, errors.Errorf("invalid args, %s", msg)
 	}
 
 	return &StrConvSet{
 		key:     args[0],
 		value:   args[1],
-		dstType: args[2],
+		dstType: destType,
 	}, nil
 }
 

--- a/pkg/interceptor/transformer/action/set.go
+++ b/pkg/interceptor/transformer/action/set.go
@@ -26,11 +26,32 @@ import (
 const (
 	SetName     = "set"
 	SetUsageMsg = "usage: set(key, value)"
+
+	SetFloatName = "setFloat"
+	SetFloatMsg  = "usage: setFloat(key, value)"
+
+	SetIntName = "setInt"
+	SetIntMsg  = "usage: setInt(key, value)"
+
+	SetBoolName = "setBool"
+	SetBoolMsg  = "usage: setBool(key, value)"
 )
 
 func init() {
 	RegisterAction(SetName, func(args []string, extra cfg.CommonCfg) (Action, error) {
 		return NewSet(args)
+	})
+	RegisterAction(SetFloatName, func(args []string, extra cfg.CommonCfg) (Action, error) {
+		args = append(args, "float")
+		return NewStrConvSet(args, SetFloatMsg)
+	})
+	RegisterAction(SetIntName, func(args []string, extra cfg.CommonCfg) (Action, error) {
+		args = append(args, "int")
+		return NewStrConvSet(args, SetIntMsg)
+	})
+	RegisterAction(SetBoolName, func(args []string, extra cfg.CommonCfg) (Action, error) {
+		args = append(args, "bool")
+		return NewStrConvSet(args, SetBoolMsg)
 	})
 }
 
@@ -53,5 +74,33 @@ func NewSet(args []string) (*Set, error) {
 
 func (a *Set) act(e api.Event) error {
 	eventops.Set(e, a.key, a.value)
+	return nil
+}
+
+type StrConvSet struct {
+	key     string
+	value   string
+	dstType string
+}
+
+func NewStrConvSet(args []string, msg string) (*StrConvSet, error) {
+	if len(args) != 3 {
+		return nil, errors.Errorf("invalid args, %s", msg)
+	}
+
+	return &StrConvSet{
+		key:     args[0],
+		value:   args[1],
+		dstType: args[2],
+	}, nil
+}
+
+func (a *StrConvSet) act(e api.Event) error {
+	dstVal, err := convert(a.value, a.dstType)
+	if err != nil {
+		return errors.Errorf("convert field %s value %v to type %s error: %v", a.key, a.value, a.dstType, err)
+	}
+
+	eventops.Set(e, a.key, dstVal)
 	return nil
 }

--- a/pkg/interceptor/transformer/action/set_test.go
+++ b/pkg/interceptor/transformer/action/set_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 Loggie Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"testing"
+
+	"github.com/loggie-io/loggie/pkg/core/api"
+	"github.com/loggie-io/loggie/pkg/core/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrConvertSet_Act(t *testing.T) {
+	assertions := assert.New(t)
+
+	type fields struct {
+		key     string
+		value   string
+		dstType string
+	}
+	type args struct {
+		e api.Event
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   api.Event
+	}{
+		{
+			name: "set bool",
+			fields: fields{
+				key:     "a.b",
+				value:   "true",
+				dstType: typeBoolean,
+			},
+			args: args{
+				e: event.NewEvent(map[string]interface{}{
+					"a": map[string]interface{}{},
+				}, []byte("this is body")),
+			},
+			want: event.NewEvent(map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": true,
+				},
+			}, []byte("this is body")),
+		},
+		{
+			name: "set int",
+			fields: fields{
+				key:     "a.b",
+				value:   "200",
+				dstType: typeInteger,
+			},
+			args: args{
+				e: event.NewEvent(map[string]interface{}{
+					"a": map[string]interface{}{},
+				}, []byte("this is body")),
+			},
+			want: event.NewEvent(map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": int64(200),
+				},
+			}, []byte("this is body")),
+		},
+		{
+			name: "set float",
+			fields: fields{
+				key:     "a.b",
+				value:   "200",
+				dstType: typeFloat,
+			},
+			args: args{
+				e: event.NewEvent(map[string]interface{}{
+					"a": map[string]interface{}{},
+				}, []byte("this is body")),
+			},
+			want: event.NewEvent(map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": float64(200),
+				},
+			}, []byte("this is body")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StrConvSet{
+				key:     tt.fields.key,
+				value:   tt.fields.value,
+				dstType: tt.fields.dstType,
+			}
+			err := s.act(tt.args.e)
+			assertions.NoError(err)
+			assertions.Equal(tt.want, tt.args.e)
+		})
+	}
+}


### PR DESCRIPTION
#### Proposed Changes:

* [interceptor/transformer] feat:support setFloat/setInt/setBool, it is the same with set + strconv, but set the value once

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #621

#### Additional documentation:

```docs
interceptor: support setFloat/setInt/setBool

1. an older configuration is：
  - type: transformer
    name: setEmpty
    actions:
    - if: NOT exist(count)
      then:
        - action: set(count, 0)
        - action: strconv(count, float)
        - action: return()
      else:
        - action: return()

2. the newly configuration is: 
  - type: transformer
    name: setEmpty
    actions:
    - if: NOT exist(count)
      then:
        - action: setFloat(count, 0)
        - action: return()
      else:
        - action: return()
```