### PR TITLE
feat: add random port option to global http

### DIFF
--- a/pkg/core/sysconfig/config.go
+++ b/pkg/core/sysconfig/config.go
@@ -88,7 +88,8 @@ func (d *Defaults) SetDefaults() {
 }
 
 type Http struct {
-	Enabled bool   `yaml:"enabled" default:"false"`
-	Host    string `yaml:"host" default:"0.0.0.0"`
-	Port    int    `yaml:"port" default:"9196"`
+	Enabled  bool   `yaml:"enabled" default:"false"`
+	Host     string `yaml:"host" default:"0.0.0.0"`
+	Port     int    `yaml:"port" default:"9196"`
+	RandPort bool   `yaml:"randPort" default:"false"`
 }


### PR DESCRIPTION
#### Proposed Changes:

I don't want loggie to fail to start on hosts that use a large number of random ports due to fixed port assignments.

#### Additional documentation:

    ```yaml
    http:
      enabled: true
      host: "0.0.0.0"
      port: 9196
      randPort: true
    ```

|    `field`   |    `type`    |  `required`  |  `default`  |  `description`  |
| ---------- | ----------- | ----------- | --------- | -------- |
| enabled | bool  |    false    |   false   | whether to enable http |
| host | string  |    false    |   0.0.0.0   | http listening host |
| port | int  |    false    |   9196   | http listening port, If 'randPort' is enabled, this configuration will be ignored |
| randPort | bool  |    false    |   false   | http listening random port |