### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/pkg/ops/helper/help.go
+++ b/pkg/ops/helper/help.go
@@ -357,7 +357,7 @@ func fileInfoMetrics(request *http.Request) (active int, inActive int, metric ma
 }
 
 func CRLF() string {
-	return fmt.Sprintf("\n")
+	return "\n"
 }
 
 func SprintfWithLF(format string, a ...interface{}) string {

--- a/test/benchmark/sink/elasticsearch/elasticsearch.go
+++ b/test/benchmark/sink/elasticsearch/elasticsearch.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/loggie-io/loggie/pkg/control"
 	"github.com/loggie-io/loggie/pkg/core/cfg"
 	"github.com/loggie-io/loggie/pkg/core/interceptor"
@@ -79,7 +78,7 @@ func main() {
 	controller := control.NewController()
 	controller.Start(pipecfgs)
 
-	if err := http.ListenAndServe(fmt.Sprintf(":9196"), nil); err != nil {
+	if err := http.ListenAndServe(":9196", nil); err != nil {
 		log.Fatal("http listen and serve err: %v", err)
 	}
 }


### PR DESCRIPTION
#### Proposed Changes:

*
*
*

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional documentation:

```docs

```