### PR TITLE
fix:fix globalWatcher is nil,when source is enable

### DIFF
--- a/pkg/source/file/watch.go
+++ b/pkg/source/file/watch.go
@@ -994,6 +994,9 @@ func ExportWatchMetric() map[string]eventbus.WatchMetricData {
 
 	watchLock.Lock()
 	defer watchLock.Unlock()
+	if globalWatcher == nil {
+		return watcherMetrics
+	}
 	for _, watchTask := range globalWatcher.sourceWatchTasks {
 		paths := getPathsIfDynamicContainerLogs(watchTask.config.Paths, watchTask.pipelineName, watchTask.sourceName)
 		m := globalWatcher.reportWatchMetric(watchTask, paths, watchTask.pipelineName, watchTask.sourceName)


### PR DESCRIPTION
#### Proposed Changes:

* When there is only one source and it is enabled, globalWatcher is nil. If the helper interface is requested later, core will occur.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

```
pipelines:
  - name: local
    sources:
      - type: file
        enabled: false
        name: demo
        paths:
          - /home/zhanglei/*.log
        fields:
          "@topic": "loggie"
    interceptors:
      - type: normalize
        name: global
        processors:
          - addMeta: ~
          - add:
              fields:
                "metadata.module": "loggie"
                "metadata.type": ""
                "metadata.version": 1.444
          - rename:
              convert:
                - from: "meta.systemState.collectTime"
                  to: "colleciton.@collectiontime"
                - from: "body"
                  to: "collection.@message"
                - from: "meta.systemState.filename"
                  to: "collection.@path"
                - from: "meta.systemState.lineNumber"
                  to: "collection.@rownumber"
          - drop:
              targets: ["meta"]

    sink:
      #      type: dev
      #      printEvents: true
      #      codec:
      #        pretty: true
      type: router
      hosts:
        - "192.168.110.117:7070"
      max_client: 1

```
Fixes #

```
if globalWatcher == nil {
		return watcherMetrics
}
```

#### Additional documentation:

```docs

```