### PR TITLE
perf: scan files at first when source start

### DIFF
--- a/pkg/source/file/watch.go
+++ b/pkg/source/file/watch.go
@@ -18,11 +18,12 @@ package file
 
 import (
 	"fmt"
-	"github.com/loggie-io/loggie/pkg/util/persistence/reg"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/loggie-io/loggie/pkg/util/persistence/reg"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/loggie-io/loggie/pkg/core/log"
@@ -726,6 +727,9 @@ func (w *Watcher) run() {
 		case <-w.done:
 			return
 		case watchTaskEvent := <-w.watchTaskEventChan:
+			if watchTaskEvent.watchTaskType == START {
+				w.scanNewFiles()
+			}
 			w.handleWatchTaskEvent(watchTaskEvent)
 		case job := <-w.zombieJobChan:
 			w.decideZombieJob(job)


### PR DESCRIPTION
#### Proposed Changes: Scan new files when a file source start.  

* 如果一个pod拥有极短的生命周期，比如2~3秒就结束，而watcher的扫描定时器是10秒，此时是不能采集到任何内容的。先扫描一次并触发inotify事件可有效避免此种情况的发生
* 如果一个pipeline匹配到了海量的小文件（如多达数十万甚至上百万个文件），那么需要等待非常久的时间才能采集得到数据，而source启动后立即扫描一遍，可加速采集到数据。
*

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional documentation:

```docs

```