### PR TITLE
feat: add STS Token support for the SLS sink

### DIFF
--- a/pkg/sink/sls/config.go
+++ b/pkg/sink/sls/config.go
@@ -17,10 +17,13 @@ limitations under the License.
 package sls
 
 type Config struct {
-	Endpoint        string `yaml:"endpoint,omitempty" validate:"required"`
-	AccessKeyId     string `yaml:"accessKeyId,omitempty" validate:"required"`
-	AccessKeySecret string `yaml:"accessKeySecret,omitempty" validate:"required"`
-	Project         string `yaml:"project,omitempty" validate:"required"`
-	LogStore        string `yaml:"logstore,omitempty" validate:"required"`
-	Topic           string `yaml:"topic,omitempty"` // empty topic is supported in sls storage
+	Endpoint                  string   `yaml:"endpoint,omitempty" validate:"required"`
+	AccessKeyId               string   `yaml:"accessKeyId,omitempty"`
+	AccessKeySecret           string   `yaml:"accessKeySecret,omitempty"`
+	CredentialProviderCommand string   `yaml:"cridentialProviderCommand,omitempty"`
+	CredentialProviderArgs    []string `yaml:"credentialProviderArgs,omitempty"`
+	CredentialProviderTimeout int      `yaml:"credentialProviderTimeout,omitempty" default:"5"`
+	Project                   string   `yaml:"project,omitempty" validate:"required"`
+	LogStore                  string   `yaml:"logstore,omitempty" validate:"required"`
+	Topic                     string   `yaml:"topic,omitempty"` // empty topic is supported in sls storage
 }

--- a/pkg/sink/sls/credentialprovider.go
+++ b/pkg/sink/sls/credentialprovider.go
@@ -1,0 +1,59 @@
+package sls
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type credentialProvider struct {
+	command   string
+	arguments []string
+	timeout   int
+}
+
+type stsCredential struct {
+	AccessKeyId     string `json:"AccessKeyId"`
+	AccessKeySecret string `json:"AccessKeySecret"`
+	SecurityToken   string `json:"SecurityToken"`
+	Expiration      string `json:"Expiration"`
+}
+
+func newCredentialProvider(command string, arguments []string, timeout int) *credentialProvider {
+	return &credentialProvider{
+		command:   command,
+		arguments: arguments,
+		timeout:   timeout,
+	}
+}
+
+func (c *credentialProvider) GetCredentials() (accessKeyId string, accessKeySecret string, securityToken string, expiration time.Time, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout)*time.Second)
+	defer cancel()
+
+	var stdout strings.Builder
+	cmd := exec.CommandContext(ctx, c.command, c.arguments...)
+	cmd.Stdout = &stdout
+
+	err = cmd.Run()
+	if err != nil {
+		return "", "", "", time.Time{}, fmt.Errorf("run credential provider command failed: %w", err)
+	}
+
+	var sts stsCredential
+	err = json.Unmarshal([]byte(stdout.String()), &sts)
+	if err != nil {
+		fmt.Printf("stdout: %s\n", stdout.String())
+		return "", "", "", time.Time{}, fmt.Errorf("unmarshal sts credential failed: %w", err)
+	}
+
+	expiration, err = time.Parse(time.RFC3339, sts.Expiration)
+	if err != nil {
+		return "", "", "", time.Time{}, fmt.Errorf("parse sts credential expiration failed: %w", err)
+	}
+
+	return sts.AccessKeyId, sts.AccessKeySecret, sts.SecurityToken, expiration, nil
+}


### PR DESCRIPTION
Use STS(Security Token Service[1]) Token can reduce the risk of long-term access key (AccessKey) leakage. The token will automatically expire after expiration date, so it need to be periodically refreshed.

There 2 ways for a user to retrieve a STS token:
- AssumeRole/AssumeRoleWithSAML/AssumeRoleWithOIDC [2]
- Access ECS metadata server [3] on an ECS instance, 

So we create a new credentialprovider to execute commands to allow end users to extend the STS refreshment without modifying the loggie itself.

1. https://www.alibabacloud.com/help/en/ram/product-overview/what-is-sts 
2. https://www.alibabacloud.com/help/en/ram/developer-reference/api-sts-2015-04-01-dir-role-assuming/ 
3. https://www.alibabacloud.com/help/en/ecs/user-guide/obtain-a-temporary-authorization-token

#### Proposed Changes:
* Allow to use SLS sink but without the access key
* A CredentialProvider for users to extend its logic to refresh the STS token

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional documentation:
##### Collect Logs on ECS without persistent credentials
Refer to [Deploy on hosts](https://loggie-io.github.io/docs-en/getting-started/install/node/). When the user has a RAM identity bound to ECS, and the RAM identity has SLS write permissions, it can be configured in this way to eliminate persistent credentials.

The pipeline configuration example is as follows:
```yaml
pipelines:
  - name: test
    sources:
      - type: file
        name: demo
        addonMeta: true
        paths:
          - /tmp/log/*.log
    sink:
      type: sls
      endpoint: cn-hangzhou.log.aliyuncs.com
      cridentialProviderCommand: curl
      credentialProviderArgs:
        - "http://100.100.100.200/latest/meta-data/ram/security-credentials/${RAM_NAME}"
      project: loggietest
      logstore: demo1
      topic: myservice
```