### PR TITLE
fix: retry interceptor goroutine blocking

### DIFF
--- a/pkg/interceptor/retry/interceptor.go
+++ b/pkg/interceptor/retry/interceptor.go
@@ -144,6 +144,7 @@ func (i *Interceptor) Intercept(invoker sink.Invoker, invocation sink.Invocation
 		rm := i.retryMeta(batch)
 		retryMaxCount := i.config.RetryMaxCount
 		if rm != nil && retryMaxCount > 0 && retryMaxCount < rm.count {
+			i.signChan <- Reset
 			return result.DropWith(errors.New(fmt.Sprintf("retry reaches the limit: retryMaxCount(%d)", retryMaxCount)))
 		}
 		i.in <- batch


### PR DESCRIPTION
Proposed Changes:
kafka/sink.go

Which issue(s) this PR fixes:
Fixes https://github.com/loggie-io/loggie/issues/668

Additional documentation:
None