### PR TITLE
Fix: insert registry when existAckOffset is zero

### DIFF
--- a/pkg/source/file/watch.go
+++ b/pkg/source/file/watch.go
@@ -319,8 +319,10 @@ func (w *Watcher) eventBus(e jobEvent) {
 			}
 		}
 		// Pre-allocation offset
-		if e.job.task.config.ReadFromTail {
-			existAckOffset = fileSize
+		if existAckOffset == 0 || e.job.task.config.ReadFromTail {
+			if e.job.task.config.ReadFromTail {
+				existAckOffset = fileSize
+			}
 			w.preAllocationOffset(existAckOffset, job)
 		}
 		// set ack offset


### PR DESCRIPTION
Fix: insert registry when existAckOffset is zero