### PR TITLE
fix: file source cannnot match path in windows #675

### DIFF
--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -108,6 +108,7 @@ func WriteFileOrCreate(dir string, filename string, content []byte) error {
 }
 
 func GlobWithRecursive(pattern string) (matches []string, err error) {
+	pattern = filepath.ToSlash(pattern)
 	dir, pattern := xglob.SplitPattern(pattern)
 	basePath := os.DirFS(dir)
 	matches = make([]string, 0)


### PR DESCRIPTION
fix: windows path like C:\tmp\*.log can match in file source